### PR TITLE
[Add]シフト提出依頼追加・スキーマ修正

### DIFF
--- a/app/controllers/shift/shift_submission_requests_controller.rb
+++ b/app/controllers/shift/shift_submission_requests_controller.rb
@@ -1,0 +1,26 @@
+class Shift::ShiftSubmissionRequestsController < ApplicationController
+	before_action :authenticate, only: [:create]
+
+	def create
+		@shift_submission_request = ShiftSubmissionRequest.new(
+			store_id: input_params['store_id'],
+			start_date: input_params['start_date'],
+			end_date: input_params['end_date'],
+			deadline_date: input_params['deadline_date'],
+			deadline_time: input_params['deadline_time'],
+			notes: input_params['notes'],
+		)
+
+		if @shift_submission_request.save
+			render json: { msg: I18n.t('shift.shift_submission_requests.create.success') }, status: 200
+		else
+			render json: { error: @shift_submission_request.errors.full_messages }, status: 400
+		end
+	end
+
+	private
+
+	def input_params
+		params.require(:shift_submission_request).permit(:start_date, :end_date, :deadline_date, :deadline_time, :notes, :store_id)
+	end
+end

--- a/app/controllers/user/users_controller.rb
+++ b/app/controllers/user/users_controller.rb
@@ -32,8 +32,7 @@ class User::UsersController < ApplicationController
 		@user = User.new(
 			user_name: user_params[:name],
 			email: user_params[:email],
-			picture: user_params[:picture],
-			privilege: 1
+			picture: user_params[:picture]
 		)
 		begin
 			ActiveRecord::Base.transaction do

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -2,4 +2,5 @@ class Membership < ApplicationRecord
 	belongs_to :user, class_name: 'User', foreign_key: 'user_id'
 	belongs_to :store, class_name: 'Store', foreign_key: 'store_id'
 
+	has_many :shifts
 end

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -1,6 +1,8 @@
 class Shift < ApplicationRecord
 	belongs_to :membership, class_name: 'Membership', foreign_key: 'membership_id'
 
+	has_many :shift_change_requests
+
 	validates :shift_date, presence: true
 	validates :is_registered, inclusion: { in: [true, false] }
 end

--- a/app/models/shift_submission_request.rb
+++ b/app/models/shift_submission_request.rb
@@ -1,0 +1,33 @@
+class ShiftSubmissionRequest < ApplicationRecord
+	belongs_to :store
+
+	validates :start_date, presence: true
+	validates :end_date, presence: true
+	validate :date_cannot_be_in_the_past
+	validate :start_date_is_less_than_end_date
+	validate :deadline_is_less_than_start_date
+
+	private
+
+	def date_cannot_be_in_the_past
+		if start_date.present? && start_date < Date.today
+			errors.add(:start_date, I18n.t("default.errors.past_date"))
+		end
+
+		if end_date.present? && end_date < Date.today
+			errors.add(:end_date, I18n.t("default.errors.past_date"))
+		end
+	end
+
+	def start_date_is_less_than_end_date
+		if start_date.present? && end_date.present? && start_date > end_date
+			errors.add(:start_date, I18n.t("default.errors.start_date_after_end_date"))
+		end
+	end
+
+	def deadline_is_less_than_start_date
+		if deadline_date.present? && start_date.present? && deadline_date > start_date
+			errors.add(:start_date, I18n.t("default.errors.deadline_date_after_end_date"))
+		end
+	end
+end

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -1,5 +1,10 @@
 class Store < ApplicationRecord
 	include IdGenerator
 
+	has_many :memberships
+	has_many :business_hours
+	has_many :shift_submission_requests
+	has_many :special_business_hours
+
 	validates :store_name, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,8 @@ class User < ApplicationRecord
 	include IdGenerator
 
 	has_many :tokens, dependent: :destroy
+	has_many :memberships
+	has_many :templates
 
 	validates :user_name, presence: true, length: {maximum: 200}
 	validates :email, presence: true, uniqueness: true

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -2,10 +2,18 @@ ja:
   defaults:
     message:
       require_login: "ログインしてください"
+    errors:
+      past_date: "過去の日付は選択できません"
+      start_date_after_end_date: "開始日時は終了日時より後の日時を選択してください"
+      deadline_date_after_end_date: "締切日時は終了日時より後の日時を選択してください"
   user:
     users:
       create:
         already_created: "ユーザは既に作成済みです"
+  shift:
+    shift_submission_requests:
+      create:
+        success: "シフト提出を依頼しました"
   jwt:
     invalid_token: "無効なトークンです"
     expired_token: "トークンの有効期限が切れています"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,8 @@ Rails.application.routes.draw do
 		# 開発用
 		get '/get_user_info', to: 'auth#get_user_info'
 	end
+
+	namespace 'shift' do
+		post '/submitShiftRequest', to: 'shift_submission_requests#create'
+	end
 end

--- a/db/migrate/20240404082250_create_shift_submission_requests.rb
+++ b/db/migrate/20240404082250_create_shift_submission_requests.rb
@@ -1,0 +1,14 @@
+class CreateShiftSubmissionRequests < ActiveRecord::Migration[7.0]
+  def change
+    create_table :shift_submission_requests, comment: "シフト提出依頼情報"  do |t|
+      t.references :store,	foreign_key: true, type: :string,	comment: "店舗情報の外部キー"
+      t.date :start_date,		null: false,					comment: "開始日"
+      t.date :end_date,			null: false,					comment: "最終日"
+      t.date :deadline_date,									comment: "締切日"
+      t.time :deadline_time,									comment: "締切時間"
+      t.text :notes,											comment: "備考"
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_01_020403) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_04_082250) do
   create_table "business_hours", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", comment: "営業時間情報", force: :cascade do |t|
     t.string "store_id", comment: "店舗情報の外部キー"
     t.integer "day_of_week", null: false, comment: "曜日"
@@ -42,6 +42,18 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_01_020403) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["shift_id"], name: "index_shift_change_requests_on_shift_id"
+  end
+
+  create_table "shift_submission_requests", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", comment: "シフト提出依頼情報", force: :cascade do |t|
+    t.string "store_id", comment: "店舗情報の外部キー"
+    t.date "start_date", null: false, comment: "開始日"
+    t.date "end_date", null: false, comment: "最終日"
+    t.date "deadline_date", comment: "締切日"
+    t.time "deadline_time", comment: "締切時間"
+    t.text "notes", comment: "備考"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["store_id"], name: "index_shift_submission_requests_on_store_id"
   end
 
   create_table "shifts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", comment: "シフト情報", force: :cascade do |t|
@@ -108,6 +120,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_01_020403) do
   add_foreign_key "memberships", "stores"
   add_foreign_key "memberships", "users"
   add_foreign_key "shift_change_requests", "shifts"
+  add_foreign_key "shift_submission_requests", "stores"
   add_foreign_key "shifts", "memberships"
   add_foreign_key "special_business_hours", "stores"
   add_foreign_key "templates", "users"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,5 @@
 ApplicationRecord.transaction do
+	ShiftSubmissionRequest.delete_all
 	Shift.delete_all
 	Membership.delete_all
 	Token.delete_all

--- a/spec/controllers/shift/shift_submission_requests_controller_spec.rb
+++ b/spec/controllers/shift/shift_submission_requests_controller_spec.rb
@@ -1,0 +1,91 @@
+require 'rails_helper'
+
+describe Shift::ShiftSubmissionRequestsController, type: :controller do
+	describe 'POST #create' do
+		let(:params) {{
+			shift_submission_request: {
+				start_date: start_date,
+				end_date: end_date,
+				deadline_date: deadline_date,
+				deadline_time: "00:00",
+				notes: "This is a test."
+			}
+		}}
+
+		context "with valid attributes" do
+			before do
+				shift_submission_request_mock = instance_double(
+					"ShiftSubmissionRequest",
+					save: true
+				)
+				allow(ShiftSubmissionRequest).to receive(:new).and_return(shift_submission_request_mock)
+			end
+
+			let(:end_date) { Date.new(2026, 01, 31) }
+			let(:deadline_date) { Date.new(2025, 12, 25) }
+
+			context "when start_date is specific date" do
+				let(:start_date) { Date.new(2026, 01, 01) }
+				it "creates a new shift submission request" do
+					post :create, params: params
+
+					expect(response).to have_http_status(200)
+					expect(response.body).to include(I18n.t('shift.shift_submission_requests.create.success'))
+				end
+			end
+
+			context "when start_date is today" do
+				let(:start_date) { Date.today }
+				it "creates a new shift submission request" do
+					post :create, params: params
+
+					expect(response).to have_http_status(200)
+					expect(response.body).to include(I18n.t('shift.shift_submission_requests.create.success'))
+				end
+			end
+		end
+
+		context "with invalid attributes" do
+			context "when start_date is in the past" do
+				let(:start_date) { Date.new(2020, 01, 01) }
+				let(:end_date) { Date.today }
+				let(:deadline_date) { Date.new(2019, 12, 30) }
+				it "do not create a shift submission request" do
+					post :create, params: params
+					expect(response).to have_http_status(400)
+				end
+			end
+
+			context "when end_date is in the past" do
+				let(:start_date) { Date.today }
+				let(:end_date) { Date.new(2020, 01, 01) }
+				let(:deadline_date) { Date.new(2019, 12, 30) }
+				it "do not create a shift submission request" do
+					post :create, params: params
+					expect(response).to have_http_status(400)
+				end
+			end
+
+			context "when start_date is less than end_date" do
+				let(:start_date) { Date.new(2026, 01, 01) }
+				let(:end_date) { Date.new(2025, 12, 30) }
+				let(:deadline_date) { Date.new(2025, 12, 25) }
+				it "do not create a shift submission request" do
+					post :create, params: params
+					expect(response).to have_http_status(400)
+				end
+			end
+
+			context "when deadline_date is less than start_date" do
+				let(:start_date) { Date.new(2026, 01, 01) }
+				let(:end_date) { Date.new(2026, 01, 30) }
+				let(:deadline_date) { Date.new(2026, 01, 15) }
+				it "do not create a shift submission request" do
+					post :create, params: params
+					expect(response).to have_http_status(400)
+				end
+			end
+		end
+
+	end
+end

--- a/spec/factories/shift_submission_request.rb
+++ b/spec/factories/shift_submission_request.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+	factory :shift_submission_request do
+		store_id { "1" }
+		start_date { Date.new(2026, 01, 01) }
+		end_date { Date.new(2026, 01, 31) }
+		deadline_date { Date.new(2025, 12, 25) }
+		deadline_time { "00:00" }
+		notes { "This is a bot." }
+	end
+end

--- a/spec/factories/store.rb
+++ b/spec/factories/store.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+	factory :store do
+		store_name { 'スーパーspec店' }
+		location { '東京都渋谷区' }
+	end
+end

--- a/spec/models/shift_submission_request_spec.rb
+++ b/spec/models/shift_submission_request_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+describe ShiftSubmissionRequest, type: :model do
+	describe 'create a new shift submission request' do
+		before do
+			@store = create(:store)
+		end
+
+		let(:shift_submission_request) do
+			ShiftSubmissionRequest.new(
+				store_id: @store.id,
+				start_date: start_date,
+				end_date: end_date,
+				deadline_date: deadline_date,
+				deadline_time: "00:00",
+				notes: "This is a test."
+			)
+		end
+		let(:start_date) { Date.new(2026, 01, 01) }
+		let(:end_date) { Date.new(2026, 01, 31) }
+		let(:deadline_date) { Date.new(2025, 12, 25) }
+
+		context "with valid attributes" do
+			it "when start_date is specific date" do
+				expect(shift_submission_request).to be_valid
+			end
+
+			it "when start_date is today" do
+				shift_submission_request.start_date = Date.today
+				shift_submission_request.deadline_date = Date.today
+				expect(shift_submission_request).to be_valid
+			end
+		end
+
+		context "with invalid attributes" do
+			it "when date is blank" do
+				shift_submission_request.start_date = ""
+				shift_submission_request.end_date = ""
+				expect(shift_submission_request).to be_invalid
+			end
+
+			it "when start_date is in the past" do
+				shift_submission_request.start_date = Date.new(2020, 01, 01)
+				shift_submission_request.deadline_date = Date.new(2019, 12, 31)
+				expect(shift_submission_request).to be_invalid
+			end
+
+			it "when end_date is in the past" do
+				shift_submission_request.end_date = Date.new(2020, 01, 01)
+				expect(shift_submission_request).to be_invalid
+			end
+
+
+			it "when start_date is less than end_date" do
+				shift_submission_request.end_date = Date.new(2025, 12, 30)
+				expect(shift_submission_request).to be_invalid
+			end
+
+			it "when deadline_date is less than start_date" do
+				shift_submission_request.deadline_date = Date.new(2026, 01, 15)
+				expect(shift_submission_request).to be_invalid
+			end
+		end
+	end
+end


### PR DESCRIPTION
## 概要
店長からスタッフへシフトの提出依頼を送信するモーダルを追加しました．
それに伴ってスキーマを調整しました．

## 変更点
- シフト提出依頼の`create`メソッド作成
- シフト提出依頼を保存する時のバリデーション追加
- コントローラとモデルのテストコード作成
- モデルの関係修正
- ユーザのprivilege削除

## 影響範囲
特になし．


## 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
- [x] `db:migrate`と`db:seed`を行ってください
- [x] `/home`にアクセス
- [x] シフト提出依頼ボタン押下
- [x] 日付等を入力し，スタッフに送信ボタン押下
- [x] 成功アラートが出れば成功
- [x] 失敗アラートが出る時は以下確認
    1. 開始日が登録日よりも過去
    2. 終了日が登録日よりも過去
    3. 終了日が開始日よりも過去
    4. 期限日が開始日よりも過去
    5. 開始日もしくは終了日が未設定

## テスト
- 動作要件に従ってテストしてください．
- `bin/rspec`を実行してテストコードを確認してください．


## 関連Issue
特になし．


## 補足
特になし．