### PR TITLE
[Add]シフト提出依頼取得機能追加

### DIFF
--- a/app/controllers/shift/shift_submission_requests_controller.rb
+++ b/app/controllers/shift/shift_submission_requests_controller.rb
@@ -1,5 +1,5 @@
 class Shift::ShiftSubmissionRequestsController < ApplicationController
-	before_action :authenticate, only: [:create]
+	before_action :authenticate, only: [:create, :wanted]
 
 	def create
 		@shift_submission_request = ShiftSubmissionRequest.new(
@@ -15,6 +15,23 @@ class Shift::ShiftSubmissionRequestsController < ApplicationController
 			render json: { msg: I18n.t('shift.shift_submission_requests.create.success') }, status: 200
 		else
 			render json: { error: @shift_submission_request.errors.full_messages }, status: 400
+		end
+	end
+
+	def wanted
+		# ログインユーザの所属情報を取得
+		@current_membership = @current_user.memberships.current.first
+		if !@current_membership
+			render json: { error: I18n.t('default.message.require_membership') }
+			return
+		end
+
+		# 募集中のシフト提出依頼を取得
+		res = ShiftSubmissionRequest.wanted(@current_membership.store_id)
+		if res
+			render json: { res: res }
+		else
+			render json: { error: I18n.t('shift.shift_submission_requests.wanted.not_found') }
 		end
 	end
 

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -3,4 +3,6 @@ class Membership < ApplicationRecord
 	belongs_to :store, class_name: 'Store', foreign_key: 'store_id'
 
 	has_many :shifts
+
+	scope :current, -> { where(current_store: true)}
 end

--- a/app/models/shift_submission_request.rb
+++ b/app/models/shift_submission_request.rb
@@ -7,6 +7,8 @@ class ShiftSubmissionRequest < ApplicationRecord
 	validate :start_date_is_less_than_end_date
 	validate :deadline_is_less_than_start_date
 
+	scope :wanted, ->(store_id) { where('store_id = ? AND deadline_date > ?',  store_id, Date.today) }
+
 	private
 
 	def date_cannot_be_in_the_past

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -2,6 +2,7 @@ ja:
   defaults:
     message:
       require_login: "ログインしてください"
+      require_membership: "所属情報が見つかりません"
     errors:
       past_date: "過去の日付は選択できません"
       start_date_after_end_date: "開始日時は終了日時より後の日時を選択してください"
@@ -14,6 +15,9 @@ ja:
     shift_submission_requests:
       create:
         success: "シフト提出を依頼しました"
+      wanted:
+        not_found: "募集中のシフト提出依頼はありません"
+
   jwt:
     invalid_token: "無効なトークンです"
     expired_token: "トークンの有効期限が切れています"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,5 +7,6 @@ Rails.application.routes.draw do
 
 	namespace 'shift' do
 		post '/submitShiftRequest', to: 'shift_submission_requests#create'
+		post '/submit_shift_request/wanted', to: 'shift_submission_requests#wanted'
 	end
 end

--- a/spec/controllers/shift/shift_submission_requests_controller_spec.rb
+++ b/spec/controllers/shift/shift_submission_requests_controller_spec.rb
@@ -7,15 +7,15 @@ describe Shift::ShiftSubmissionRequestsController, type: :controller do
 				start_date: start_date,
 				end_date: end_date,
 				deadline_date: deadline_date,
-				deadline_time: "00:00",
-				notes: "This is a test."
+				deadline_time: '00:00',
+				notes: 'This is a test.'
 			}
 		}}
 
-		context "with valid attributes" do
+		context 'with valid attributes' do
 			before do
 				shift_submission_request_mock = instance_double(
-					"ShiftSubmissionRequest",
+					'ShiftSubmissionRequest',
 					save: true
 				)
 				allow(ShiftSubmissionRequest).to receive(:new).and_return(shift_submission_request_mock)
@@ -86,6 +86,5 @@ describe Shift::ShiftSubmissionRequestsController, type: :controller do
 				end
 			end
 		end
-
 	end
 end

--- a/spec/factories/membership.rb
+++ b/spec/factories/membership.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+	factory :membership do
+		association :user
+		association :store
+		current_store { true }
+		calendar_id { "" }
+		privilege { 1 }
+	end
+end

--- a/spec/factories/shift_submission_request.rb
+++ b/spec/factories/shift_submission_request.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
 	factory :shift_submission_request do
-		store_id { "1" }
+		association :store
 		start_date { Date.new(2026, 01, 01) }
 		end_date { Date.new(2026, 01, 31) }
 		deadline_date { Date.new(2025, 12, 25) }

--- a/spec/factories/store.rb
+++ b/spec/factories/store.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
 	factory :store do
-		store_name { 'スーパーspec店' }
+		sequence(:store_name) { |n| "スーパーspec#{n}号店" }
 		location { '東京都渋谷区' }
 	end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+	factory :user, aliases: [:owner] do
+		sequence(:user_name) { |n| "minshif Test User #{n}" }
+		sequence(:email) { |n| "minshif#{n}@gmail.com" }
+		picture { "https://play-lh.googleusercontent.com/ZyWNGIfzUyoajtFcD7NhMksHEZh37f-MkHVGr5Yfefa-IX7yj9SMfI82Z7a2wpdKCA=w240-h480-rw" }
+	end
+end


### PR DESCRIPTION
## 概要
ユーザ側からシフト提出依頼を取得する機能を追加しました．
募集中のシフト提出依頼のみを返すように実装しました．


## 変更点
- シフト提出依頼の取得を行うwanted関数を追加
- jwtトークンを含んだリクエストなのでPOST通信のルーティング追加
- membership, shift_submission_requestのscopeを追加
- FactoryBot追加


## 影響範囲
ユーザのログイン管理．


## 動作要件
- [ ] ログイン状態で行う必要がある
    - JWT Tokenを使う
    - membership情報からシフト提出依頼の取得を行う

## テスト
- /create_shift（**WIPのため要更新**）へ初回アクセス時に自動で取得される．


## 関連Issue
特になし．

## 補足
テストコードまだ書けてないため要追加