### PR TITLE
[Add]JWT認証追加

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,6 +205,8 @@ GEM
     nio4r (2.5.9)
     nokogiri (1.15.4-aarch64-linux)
       racc (~> 1.4)
+    nokogiri (1.15.4-arm64-darwin)
+      racc (~> 1.4)
     os (1.1.4)
     popper_js (1.16.1)
     psych (5.1.1.1)
@@ -342,6 +344,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  arm64-darwin-22
 
 DEPENDENCIES
   bcrypt (~> 3.1.7)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,7 @@ class ApplicationController < ActionController::API
 
 	# 現在ログイン中のユーザ管理
 	def authenticate
-		raise AuthenticationError, t('defaults.message.require_login') unless current_user
+		raise AuthenticationError, I18n.t('defaults.message.require_login') unless current_user
 	end
 
 	private

--- a/app/controllers/user/users_controller.rb
+++ b/app/controllers/user/users_controller.rb
@@ -1,4 +1,6 @@
 class User::UsersController < ApplicationController
+	before_action :authenticate, only: [:get_user_info]
+
 	def create
 		result = UserService.create_with_token(input_token_params, input_invitation_params)
 		if result[:success?]
@@ -9,9 +11,11 @@ class User::UsersController < ApplicationController
 	end
 
 	def get_user_info
-		user_id = cookies[:user_id]
-		user = User.find_by(id: user_id) if user_id.present?
-		render json: { user: user }
+		if @current_user
+			render json: { user: @current_user }
+		else
+			render json: { error: I18n.t('user.users.get_user_info.failed') }, status: bad_request
+		end
 	end
 
 	private

--- a/app/services/jwt/token_decryptor.rb
+++ b/app/services/jwt/token_decryptor.rb
@@ -8,8 +8,14 @@ module Jwt::TokenDecryptor
 	private
 
 	def decrypt(token)
-		JWT.decode(token, Rails.application.credentials.secret_key_base, true, { algorithm: 'HS256' })
-	rescue JWT::DecodeError
-		{ error: t('jwt.invalid_token') }
+		begin
+			JWT.decode(token, Rails.application.credentials.secret_key_base, true, { iss: ENV['JWT_ISS'], verify_iss: true, algorithm: 'HS256' })
+		rescue JWT::ExpiredSignature
+			{ error: I18n.t('jwt.expired_token') }
+		rescue JWT::InvalidIssuerError
+			{ error: I18n.t('jwt.invalid_token') }
+		rescue JWT::DecodeError
+			{ error: I18n.t('jwt.invalid_token') }
+		end
 	end
 end

--- a/app/services/jwt/token_provider.rb
+++ b/app/services/jwt/token_provider.rb
@@ -2,7 +2,11 @@ module Jwt::TokenProvider
 	extend self
 
 	def call(user_id)
-		payload = { user_id: user_id, exp: (DateTime.current + 1.months).to_i }
+		payload = {
+			iss: ENV['JWT_ISS'],
+			user_id: user_id,
+			exp: (DateTime.current + 1.months).to_i
+		}
 		issue_token(payload)
 	end
 

--- a/app/services/jwt/user_authenticator.rb
+++ b/app/services/jwt/user_authenticator.rb
@@ -3,6 +3,8 @@ module Jwt::UserAuthenticator
 
 	def call(request_headers)
 		@request_headers = request_headers
+		return { error: I18n.t('jwt.invalid_headers') } if @request_headers['Authorization'].blank?
+
 		begin
 			# decodeしたトークン(payload)とヘッダー情報(_)を格納
 			payload, = Jwt::TokenDecryptor.call(token)

--- a/app/services/jwt/user_authenticator.rb
+++ b/app/services/jwt/user_authenticator.rb
@@ -3,7 +3,7 @@ module Jwt::UserAuthenticator
 
 	def call(request_headers)
 		@request_headers = request_headers
-		return { error: I18n.t('jwt.invalid_headers') } if @request_headers['Authorization'].blank?
+		return { error: I18n.t('jwt.invalid_headers') } if token.blank?
 
 		begin
 			# decodeしたトークン(payload)とヘッダー情報(_)を格納

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -38,6 +38,7 @@ ja:
     invalid_token: "無効なトークンです"
     expired_token: "トークンの有効期限が切れています"
     unauthorized: "認証に失敗しました"
+    invalid_headers: "ヘッダーが不正です"
   google:
     failed_api_request: "APIリクエストに失敗しました"
   user_mailer:

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -12,6 +12,8 @@ ja:
       create:
         already_created: "ユーザは既に作成済みです"
         success: "ユーザを作成しました"
+      get_user_info:
+        failed: "ユーザが見つかりませんでした"
   shift:
     shift_submission_requests:
       create:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,7 @@
 Rails.application.routes.draw do
 	namespace 'user' do
 		post '/create', to: 'users#create'
-		# 開発用
-		get '/get_user_info', to: 'users#get_user_info'
+		post '/get_user_info', to: 'users#get_user_info'
 	end
 
 	namespace 'shift' do

--- a/spec/controllers/shift/shift_submission_requests_controller_spec.rb
+++ b/spec/controllers/shift/shift_submission_requests_controller_spec.rb
@@ -11,9 +11,12 @@ RSpec.describe Shift::ShiftSubmissionRequestsController, type: :controller do
 				notes: 'This is a test.'
 			}
 		}}
+		let(:user) { create(:user) }
+		let(:token) { Jwt::TokenProvider.call(user_id: user.id) }
 
 		context 'with valid attributes' do
 			before do
+				request.headers['Authorization'] = "Bearer #{token}"
 				shift_submission_request_mock = instance_double(
 					'ShiftSubmissionRequest',
 					save: true
@@ -46,6 +49,10 @@ RSpec.describe Shift::ShiftSubmissionRequestsController, type: :controller do
 		end
 
 		context "with invalid attributes" do
+			before do
+				request.headers['Authorization'] = "Bearer #{token}"
+			end
+
 			context "when start_date is in the past" do
 				let(:start_date) { Date.new(2020, 01, 01) }
 				let(:end_date) { Date.today }

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -70,4 +70,25 @@ RSpec.describe User::UsersController, type: :controller do
 			end
 		end
 	end
+
+	describe 'POST#get_user_info' do
+		let(:user) { create(:user) }
+		let(:token) { Jwt::TokenProvider.call(user.id) }
+
+		before do
+			request.headers['Authorization'] = "Bearer #{token}"
+		end
+
+		it 'when the user information is correct' do
+			post :get_user_info
+
+			expect(response).to have_http_status(200)
+			expect(JSON.parse(response.body)['user']).to include({
+				'id' => user.id,
+				'user_name' => user.user_name,
+				'email' => user.email,
+				'picture' => user.picture
+			})
+		end
+	end
 end


### PR DESCRIPTION
## 概要
JWTの認証を追加して，ユーザ管理ができるようになりました．


## 変更点
- JWT認証と復号にissuerを追加
- ヘッダが空の場合エラーを返却


## 影響範囲
- ログインが必要な処理の前にユーザ管理を行う


## 動作要件
- [ ] request.headers['Authorization']にJWTトークンを付与してリクエストする


## テスト
- ヘッダにAuthorizationを含めてログインが必要な処理にリクエストする
- 失敗例
    - ヘッダにAuthorizationを含めずリクエストした場合
    - JWTトークンがこのアプリケーションで生成されたものではない場合
    - JWTトークンの有効期限が過ぎている場合

## 関連Issue
特になし

## 補足
JWTトークンのリフレッシュ処理がまだ実装できていない．

現時点での考えとしては，以下の2つ
1. JWT認証を別のリクエストで行い，ユーザ管理する
2. DBで有効期限を管理


- ひとまず，有効期限のリフレッシュは再度ログインした時に行うこととする．
    - ※セッションの途中で有効期限が切れてしまうため要改善！
