### PR TITLE
[Fix]シフト提出依頼と希望シフトの関連付け

### DIFF
--- a/app/controllers/shift/preferred_shifts_controller.rb
+++ b/app/controllers/shift/preferred_shifts_controller.rb
@@ -1,0 +1,34 @@
+class Shift::PreferredShiftsController < ApplicationController
+	before_action :authenticate, only: [:create]
+
+	def create
+		begin
+			validated_shifts = input_params.map do |shift_params|
+				shift = Shift.new(
+					membership_id: @current_user.memberships.current.first.id,
+					shift_date: shift_params[:date],
+					start_time: shift_params[:startTime],
+					end_time: shift_params[:endTime],
+					notes: shift_params[:notes]
+				)
+
+				validator = ShiftValidator.new(shift, @current_user)
+				validator.validate
+				shift
+			end
+
+			Shift.create_preferred_shifts!(validated_shifts, @current_user)
+			render json: { msg: I18n.t('shift.preferred_shifts.create.success'), status: 200 }, status: :ok
+		rescue ActiveRecord::RecordInvalid => e
+			render json: { error: e.record.errors.full_messages }, status: :bad_request
+		end
+	end
+
+	private
+
+	def input_params
+		params.require(:preferredShifts).map do |shift|
+			shift.permit(:date, :startTime, :endTime, :notes)
+		end
+	end
+end

--- a/app/controllers/shift/preferred_shifts_controller.rb
+++ b/app/controllers/shift/preferred_shifts_controller.rb
@@ -6,6 +6,7 @@ class Shift::PreferredShiftsController < ApplicationController
 			validated_shifts = input_params.map do |shift_params|
 				shift = Shift.new(
 					membership_id: @current_user.memberships.current.first.id,
+					shift_submission_request_id: shift_params[:shift_submission_request_id],
 					shift_date: shift_params[:date],
 					start_time: shift_params[:startTime],
 					end_time: shift_params[:endTime],
@@ -28,7 +29,7 @@ class Shift::PreferredShiftsController < ApplicationController
 
 	def input_params
 		params.require(:preferredShifts).map do |shift|
-			shift.permit(:date, :startTime, :endTime, :notes)
+			shift.permit(:shift_submission_request_id, :date, :startTime, :endTime, :notes)
 		end
 	end
 end

--- a/app/controllers/shift/shift_submission_requests_controller.rb
+++ b/app/controllers/shift/shift_submission_requests_controller.rb
@@ -27,11 +27,11 @@ class Shift::ShiftSubmissionRequestsController < ApplicationController
 		end
 
 		# 募集中のシフト提出依頼を取得
-		res = ShiftSubmissionRequest.wanted(@current_membership.store_id)
-		if res
-			render json: { res: res }
+		data = ShiftSubmissionRequest.wanted(@current_membership.store_id)
+		if data
+			render json: { data: data, status: 200 }
 		else
-			render json: { error: I18n.t('shift.shift_submission_requests.wanted.not_found') }
+			render json: { error: I18n.t('shift.shift_submission_requests.wanted.not_found'), status: 400 }
 		end
 	end
 

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -1,5 +1,6 @@
 class Shift < ApplicationRecord
 	belongs_to :membership, class_name: 'Membership', foreign_key: 'membership_id'
+	belongs_to :shift_submission_request, foreign_key: 'shift_submission_request_id'
 
 	has_many :shift_change_requests
 

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -5,4 +5,12 @@ class Shift < ApplicationRecord
 
 	validates :shift_date, presence: true
 	validates :is_registered, inclusion: { in: [true, false] }
+
+	def self.create_preferred_shifts!(shifts, user)
+		ActiveRecord::Base.transaction do
+			shifts.map do |shift|
+				shift.save!
+			end
+		end
+	end
 end

--- a/app/models/shift_submission_request.rb
+++ b/app/models/shift_submission_request.rb
@@ -1,6 +1,8 @@
 class ShiftSubmissionRequest < ApplicationRecord
 	belongs_to :store
 
+	has_many :shifts
+
 	validates :start_date, presence: true
 	validates :end_date, presence: true
 	validate :date_cannot_be_in_the_past

--- a/app/validators/shift_validator.rb
+++ b/app/validators/shift_validator.rb
@@ -1,0 +1,32 @@
+require "date"
+
+class ShiftValidator
+	def initialize(shift, user)
+		@shift = shift
+		@user = user
+	end
+
+	def validate
+		validate_date_range
+		validate_time
+		raise ActiveRecord::RecordInvalid.new(@shift) unless @shift.errors.empty?
+	end
+
+	private
+
+	def validate_date_range
+		shift_membership = @user.memberships.current.first
+		shift_request = ShiftSubmissionRequest.find_by(store_id: shift_membership.store_id)
+		reg_date = @shift.shift_date.strftime('%Y-%m-%d')
+
+		if !shift_request || Date.parse(reg_date) < shift_request.start_date || Date.parse(reg_date) > shift_request.end_date
+			@shift.errors.add(:shift_date, I18n.t("shift.preferred_shifts.create.out_of_range"))
+		end
+	end
+
+	def validate_time
+		if @shift.start_time > @shift.end_time
+			@shift.errors.add(:start_time, I18n.t("preferred_shifts.create.invalid_time"))
+		end
+	end
+end

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -20,6 +20,12 @@ ja:
         success: "シフト提出を依頼しました"
       wanted:
         not_found: "募集中のシフト提出依頼はありません"
+    preferred_shifts:
+      create:
+        success: "希望シフトを登録しました"
+        failure: "希望シフトの登録に失敗しました"
+        invalid_time: "時間が無効です"
+        out_of_range: "時間が範囲外です"
   store:
     stores:
       create:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
 	namespace 'shift' do
 		post '/preferred_shifts', to: 'preferred_shifts#create'
 		post '/submitShiftRequest', to: 'shift_submission_requests#create'
-		post '/submit_shift_request/wanted', to: 'shift_submission_requests#wanted'
+		get '/fetch_shift_request', to: 'shift_submission_requests#wanted'
 	end
 
 	namespace 'store' do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
 	end
 
 	namespace 'shift' do
+		post '/preferred_shifts', to: 'preferred_shifts#create'
 		post '/submitShiftRequest', to: 'shift_submission_requests#create'
 		post '/submit_shift_request/wanted', to: 'shift_submission_requests#wanted'
 	end

--- a/db/migrate/20240625073502_add_shift_submission_request_id_to_shift.rb
+++ b/db/migrate/20240625073502_add_shift_submission_request_id_to_shift.rb
@@ -1,0 +1,7 @@
+class AddShiftSubmissionRequestIdToShift < ActiveRecord::Migration[7.0]
+  def change
+    add_column :shifts, :shift_submission_request_id, :bigint, comment: "シフト提出依頼の外部キー"
+    add_index :shifts, :shift_submission_request_id
+    add_foreign_key :shifts, :shift_submission_requests, column: :shift_submission_request_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_30_095121) do
+ActiveRecord::Schema[7.0].define(version: 2024_06_25_073502) do
   create_table "business_hours", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", comment: "営業時間情報", force: :cascade do |t|
     t.string "store_id", comment: "店舗情報の外部キー"
     t.integer "day_of_week", null: false, comment: "曜日"
@@ -75,7 +75,9 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_30_095121) do
     t.boolean "is_registered", default: false, comment: "登録状態"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "shift_submission_request_id", comment: "シフト提出依頼の外部キー"
     t.index ["membership_id"], name: "index_shifts_on_membership_id"
+    t.index ["shift_submission_request_id"], name: "index_shifts_on_shift_submission_request_id"
   end
 
   create_table "special_business_hours", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", comment: "特別営業日情報", force: :cascade do |t|
@@ -133,6 +135,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_30_095121) do
   add_foreign_key "shift_change_requests", "shifts"
   add_foreign_key "shift_submission_requests", "stores"
   add_foreign_key "shifts", "memberships"
+  add_foreign_key "shifts", "shift_submission_requests"
   add_foreign_key "special_business_hours", "stores"
   add_foreign_key "templates", "users"
   add_foreign_key "tokens", "users"

--- a/spec/controllers/shift/preferred_shifts_controller_spec.rb
+++ b/spec/controllers/shift/preferred_shifts_controller_spec.rb
@@ -5,15 +5,17 @@ RSpec.describe Shift::PreferredShiftsController, type: :controller do
 		let(:user) { create(:user) }
 		let!(:membership) { create(:membership, user: user, current_store: true) }
 		let(:token) { Jwt::TokenProvider.call(user.id) }
+		let(:store) { create(:store) }
+		let(:shift_submission_request) { create(:shift_submission_request, store: store) }
 		let(:params) {{
 			preferredShifts: [
-				{date: date, start_time: start_time, end_time: end_time, notes: notes}
+				{shift_submission_request_id: shift_submission_request.id, date: date, startTime: startTime, endTime: endTime, notes: notes}
 			]
 		}}
 
 		let(:date) { Date.today }
-		let(:start_time) { Time.parse('09:00:00') }
-		let(:end_time) { Time.parse('18:00:00') }
+		let(:startTime) { Time.parse('09:00:00') }
+		let(:endTime) { Time.parse('18:00:00') }
 		let(:notes) { 'test note' }
 
 		let(:shift_request) { build(:shift_submission_request, store_id: membership.store_id, start_date: Date.yesterday, end_date: Date.tomorrow) }
@@ -44,9 +46,9 @@ RSpec.describe Shift::PreferredShiftsController, type: :controller do
 			context 'when dates are multiple' do
 				let(:params) {{
 					preferredShifts: [
-						{date: date, start_time: start_time, end_time: end_time, notes: notes},
-						{date: date, start_time: start_time, end_time: end_time, notes: notes},
-						{date: date, start_time: start_time, end_time: end_time, notes: notes}
+						{shift_submission_request_id: shift_submission_request.id, date: date, startTime: startTime, endTime: endTime, notes: notes},
+						{shift_submission_request_id: shift_submission_request.id, date: date, startTime: startTime, endTime: endTime, notes: notes},
+						{shift_submission_request_id: shift_submission_request.id, date: date, startTime: startTime, endTime: endTime, notes: notes}
 					]
 				}}
 
@@ -71,10 +73,10 @@ RSpec.describe Shift::PreferredShiftsController, type: :controller do
 			end
 
 			context 'when setting incorrect time' do
-				let(:start_time) { Time.parse('18:00:00') }
-				let(:end_time) { Time.parse('09:00:00') }
+				let(:startTime) { Time.parse('18:00:00') }
+				let(:endTime) { Time.parse('09:00:00') }
 
-				it 'is not valid and adds an error on start_time' do
+				it 'is not valid and adds an error on startTime' do
 					post :create, params: params
 					expect(response).to have_http_status(400)
 				end

--- a/spec/controllers/shift/preferred_shifts_controller_spec.rb
+++ b/spec/controllers/shift/preferred_shifts_controller_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+RSpec.describe Shift::PreferredShiftsController, type: :controller do
+	describe 'POST #create' do
+		let(:user) { create(:user) }
+		let!(:membership) { create(:membership, user: user, current_store: true) }
+		let(:token) { Jwt::TokenProvider.call(user.id) }
+		let(:params) {{
+			preferredShifts: [
+				{date: date, start_time: start_time, end_time: end_time, notes: notes}
+			]
+		}}
+
+		let(:date) { Date.today }
+		let(:start_time) { Time.parse('09:00:00') }
+		let(:end_time) { Time.parse('18:00:00') }
+		let(:notes) { 'test note' }
+
+		let(:shift_request) { build(:shift_submission_request, store_id: membership.store_id, start_date: Date.yesterday, end_date: Date.tomorrow) }
+
+		before do
+			allow(ShiftSubmissionRequest).to receive(:find_by).and_return(shift_request)
+		end
+
+		context 'with valid attributes' do
+			before do
+				request.headers['Authorization'] = "Bearer #{token}"
+			end
+
+			context 'when the date is a single' do
+				it 'is valid and adds a new preferred shift' do
+					post :create, params: params
+					expect(response).to have_http_status(200)
+				end
+
+				it 'is valid and note is nil' do
+					modified_params = params.deep_dup
+					modified_params[:preferredShifts][0][:notes] = nil
+					post :create, params: modified_params
+					expect(response).to have_http_status(200)
+				end
+			end
+
+			context 'when dates are multiple' do
+				let(:params) {{
+					preferredShifts: [
+						{date: date, start_time: start_time, end_time: end_time, notes: notes},
+						{date: date, start_time: start_time, end_time: end_time, notes: notes},
+						{date: date, start_time: start_time, end_time: end_time, notes: notes}
+					]
+				}}
+
+				it 'is valid and adds a new preferred shift' do
+					post :create, params: params
+					expect(response).to have_http_status(200)
+				end
+			end
+		end
+
+		context 'with invalid attributes' do
+			before do
+				request.headers['Authorization'] = "Bearer #{token}"
+			end
+
+			context 'when setting incorrect date' do
+				let(:date) { Date.parse('2026-01-07') }
+				it 'is not valid and adds an error on shift_date' do
+					post :create, params: params
+					expect(response).to have_http_status(400)
+				end
+			end
+
+			context 'when setting incorrect time' do
+				let(:start_time) { Time.parse('18:00:00') }
+				let(:end_time) { Time.parse('09:00:00') }
+
+				it 'is not valid and adds an error on start_time' do
+					post :create, params: params
+					expect(response).to have_http_status(400)
+				end
+			end
+		end
+	end
+end

--- a/spec/factories/membership.rb
+++ b/spec/factories/membership.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
 	factory :membership do
-		association :user
-		association :store
+		association :user, factory: :user
+		association :store, factory: :store
 		current_store { true }
 		calendar_id { "" }
 		privilege { 1 }

--- a/spec/factories/preferred_shift.rb
+++ b/spec/factories/preferred_shift.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+	factory :preferred_shift do
+		association :membership
+		shift_date { Date.new(2024, 10, 10) }
+		start_time { Time.parse('09:00:00') }
+		end_time { Time.parse('18:00:00') }
+		notes { "" }
+		is_registered { false }
+	end
+end


### PR DESCRIPTION
## 概要
希望シフト登録機能の追加を行った．

## 変更点
- 希望シフトが提出されると所属情報を加えてシフトを保存する処理を追加
- シフトテーブルにシフト提出依頼のIDを外部IDとして追加
- 
- スタッフが希望シフトを提出する際にどのシフト提出依頼に対して提出したかを判定するための修正


## 影響範囲
このセクションでは、このPRが影響を及ぼす範囲や他の機能への影響を説明してください。


## 動作要件
- [ ] DBの更新
    - `docker-compose exec api rails db:migrate`
- [ ] テストの実行


## テスト
- rspecの実行
1. 管理者がシフト提出依頼を出す
2. スタッフは，「希望シフト提出」ボタンから希望シフトを作成
3. 履歴からも追加できるか確認
4. 完成後，提出ボタンから提出
5. 提出時にそれぞれのシフトのバリデーションを行い，正しければshiftテーブルに追加される

## 関連Issue
なし


## 補足
- 希望シフト提出時にスタッフのmembership_idやshift_submission_request_idが保存できているか確認