### PR TITLE
[Add]登録予定シフト処理追加

### DIFF
--- a/app/controllers/shift/draft_shifts_controller.rb
+++ b/app/controllers/shift/draft_shifts_controller.rb
@@ -1,0 +1,25 @@
+class Shift::DraftShiftsController < ApplicationController
+	before_action :authenticate, only: [:create]
+
+	def create
+		if @current_user.memberships.current.first.privilege == "staff"
+			render json: { error: I18n.t('shift.draft_shifts.create.no_privilege') }, status: :bad_request
+			return
+		end
+
+		begin
+			Shift.register_draft_shifts!(input_params, @current_user)
+			render json: { message: I18n.t('shift.draft_shifts.create.success'), status: :ok }
+		rescue ActiveRecord::RecordInvalid => e
+			render json: { error: e.message }, status: :bad_request
+		end
+	end
+
+	private
+
+	def input_params
+		params.require(:draft_shifts).map do |shift|
+			shift.permit(:id, :user_name, :date, :start_time, :end_time, :notes, :is_registered, :shift_submission_request_id)
+		end
+	end
+end

--- a/app/controllers/shift/draft_shifts_controller.rb
+++ b/app/controllers/shift/draft_shifts_controller.rb
@@ -9,7 +9,7 @@ class Shift::DraftShiftsController < ApplicationController
 
 		begin
 			Shift.register_draft_shifts!(input_params, @current_user)
-			render json: { message: I18n.t('shift.draft_shifts.create.success'), status: :ok }
+			render json: { message: I18n.t('shift.draft_shifts.create.success') }, status: :ok
 		rescue ActiveRecord::RecordInvalid => e
 			render json: { error: e.message }, status: :bad_request
 		end

--- a/app/controllers/shift/preferred_shifts_controller.rb
+++ b/app/controllers/shift/preferred_shifts_controller.rb
@@ -3,25 +3,10 @@ class Shift::PreferredShiftsController < ApplicationController
 
 	def create
 		begin
-			validated_shifts = input_params.map do |shift_params|
-				shift = Shift.new(
-					membership_id: @current_user.memberships.current.first.id,
-					shift_submission_request_id: shift_params[:shift_submission_request_id],
-					shift_date: shift_params[:date],
-					start_time: shift_params[:startTime],
-					end_time: shift_params[:endTime],
-					notes: shift_params[:notes]
-				)
-
-				validator = ShiftValidator.new(shift, @current_user)
-				validator.validate
-				shift
-			end
-
-			Shift.create_preferred_shifts!(validated_shifts, @current_user)
-			render json: { msg: I18n.t('shift.preferred_shifts.create.success'), status: 200 }, status: :ok
+			Shift.register_preferred_shifts!(input_params, @current_user)
+			render json: { msg: I18n.t('shift.preferred_shifts.create.success'), status: :ok }
 		rescue ActiveRecord::RecordInvalid => e
-			render json: { error: e.record.errors.full_messages }, status: :bad_request
+			render json: { error: e.message }, status: :bad_request
 		end
 	end
 
@@ -29,7 +14,7 @@ class Shift::PreferredShiftsController < ApplicationController
 
 	def input_params
 		params.require(:preferredShifts).map do |shift|
-			shift.permit(:shift_submission_request_id, :date, :startTime, :endTime, :notes)
+			shift.permit(:shift_submission_request_id, :date, :start_time, :end_time, :notes, :is_registered)
 		end
 	end
 end

--- a/app/controllers/shift/preferred_shifts_controller.rb
+++ b/app/controllers/shift/preferred_shifts_controller.rb
@@ -4,7 +4,7 @@ class Shift::PreferredShiftsController < ApplicationController
 	def create
 		begin
 			Shift.register_preferred_shifts!(input_params, @current_user)
-			render json: { msg: I18n.t('shift.preferred_shifts.create.success'), status: :ok }
+			render json: { msg: I18n.t('shift.preferred_shifts.create.success') }, status: :ok
 		rescue ActiveRecord::RecordInvalid => e
 			render json: { error: e.message }, status: :bad_request
 		end

--- a/app/controllers/shift/shift_submission_requests_controller.rb
+++ b/app/controllers/shift/shift_submission_requests_controller.rb
@@ -12,9 +12,9 @@ class Shift::ShiftSubmissionRequestsController < ApplicationController
 		)
 
 		if @shift_submission_request.save
-			render json: { msg: I18n.t('shift.shift_submission_requests.create.success') }, status: 200
+			render json: { msg: I18n.t('shift.shift_submission_requests.create.success') }, status: :ok
 		else
-			render json: { error: @shift_submission_request.errors.full_messages }, status: 400
+			render json: { error: @shift_submission_request.errors.full_messages }, status: :bad_request
 		end
 	end
 
@@ -29,9 +29,9 @@ class Shift::ShiftSubmissionRequestsController < ApplicationController
 		# 募集中のシフト提出依頼を取得
 		data = ShiftSubmissionRequest.wanted(@current_membership.store_id)
 		if data
-			render json: { data: data, status: 200 }
+			render json: { data: data }, status: :ok
 		else
-			render json: { error: I18n.t('shift.shift_submission_requests.wanted.not_found'), status: 400 }
+			render json: { error: I18n.t('shift.shift_submission_requests.wanted.not_found') }, status: :bad_request
 		end
 	end
 

--- a/app/controllers/shift/shifts_controller.rb
+++ b/app/controllers/shift/shifts_controller.rb
@@ -25,13 +25,14 @@ class Shift::ShiftsController < ApplicationController
 				end
 
 				{
-					id: staff.user.id,
+					id: shift.id,
 					user_name: staff.user.user_name,
 					date: shift.shift_date,
 					start_time: shift.start_time,
 					end_time: shift.end_time,
 					notes: shift.notes,
-					is_registered: shift.is_registered
+					is_registered: shift.is_registered,
+					shift_submission_request_id: shift.shift_submission_request_id
 				}
 			end.compact
 		end

--- a/app/controllers/user/users_controller.rb
+++ b/app/controllers/user/users_controller.rb
@@ -4,7 +4,7 @@ class User::UsersController < ApplicationController
 	def create
 		result = UserService.create_with_token(input_token_params, input_invitation_params)
 		if result[:success?]
-			render json: { msg: result[:msg], token: result[:token], user_id: result[:user_id], is_new_user: result[:is_new_user] }
+			render json: { msg: result[:msg], token: result[:token], user_id: result[:user_id], is_new_user: result[:is_new_user] }, status: :ok
 		else
 			render json: { error: result[:error] }, status: :unprocessable_entity
 		end

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -1,17 +1,83 @@
 class Shift < ApplicationRecord
 	belongs_to :membership, class_name: 'Membership', foreign_key: 'membership_id'
-	belongs_to :shift_submission_request, foreign_key: 'shift_submission_request_id'
+	belongs_to :shift_submission_request, optional: true, foreign_key: 'shift_submission_request_id'
 
 	has_many :shift_change_requests
 
 	validates :shift_date, presence: true
 	validates :is_registered, inclusion: { in: [true, false] }
 
-	def self.create_preferred_shifts!(shifts, user)
+	scope :with_id, ->(id) { where(id: id) }
+	scope :registered_shift_for_date, ->(membership_id, shift_date) { where(membership_id: membership_id, shift_date: shift_date, is_registered: true) }
+
+	def self.register_draft_shifts!(shifts_params, current_user)
+		register_shifts!(shifts_params, current_user, true)
+	end
+
+	def self.register_preferred_shifts!(shifts_params, current_user)
+		register_shifts!(shifts_params, current_user, false)
+	end
+
+	private
+
+	def self.register_shifts!(shifts_params, current_user, is_draft_shifts)
 		ActiveRecord::Base.transaction do
-			shifts.map do |shift|
-				shift.save!
+			shifts_params.each do |shift_params|
+				membership_id = find_membership_id(shift_params, current_user, is_draft_shifts)
+				raise ActiveRecord::RecordInvalid.new("Membership not found") if membership_id.nil?
+
+				shift = build_shift(shift_params, membership_id)
+				validate_shift!(shift, shift_params[:shift_submission_request_id])
+
+				# シフトが既に登録済みなら更新
+				registered_shift = registered_shift_for_date(shift.membership_id, shift.shift_date).first
+				if registered_shift.present?
+					registered_shift.update!(
+						start_time: shift.start_time,
+						end_time: shift.end_time,
+						notes: shift.notes,
+						is_registered: shift.is_registered,
+						shift_submission_request_id: shift.shift_submission_request_id
+					)
+				else
+					shift.save!
+				end
 			end
 		end
+	end
+
+	def self.find_membership_id(shift_params, current_user, is_draft_shifts)
+		if is_draft_shifts
+			shift = Shift.with_id(shift_params[:id]).first
+			return shift.membership_id if shift.present?
+
+			# 希望シフトがない日付からの登録時にユーザ名で検索
+			user = User.find_by(user_name: shift_params[:user_name])
+			raise ActiveRecord::RecordInvalid.new("User not found") if user.nil?
+
+			membership = Membership.where(user_id: user.id, store_id: current_user.memberships.current.first.store_id).first
+			return membership.id if membership.present?
+
+			raise ActiveRecord::RecordInvalid.new("Membership not found")
+		else
+			current_user.memberships.current.first.id
+		end
+	end
+
+	def self.build_shift(shift_params, membership_id)
+		Shift.new(
+			membership_id: membership_id,
+			shift_submission_request_id: shift_params[:shift_submission_request_id],
+			shift_date: shift_params[:date],
+			start_time: shift_params[:start_time],
+			end_time: shift_params[:end_time],
+			notes: shift_params[:notes],
+			is_registered: shift_params[:is_registered]
+		)
+	end
+
+	def self.validate_shift!(shift, shift_submission_request_id)
+		validator = ShiftValidator.new(shift, shift_submission_request_id)
+		validator.validate
 	end
 end

--- a/app/services/token_service.rb
+++ b/app/services/token_service.rb
@@ -67,7 +67,7 @@ class TokenService
 			# access_tokenを更新
 			token_params = AuthController.new(refresh_token: refresh_token).get_token
 			if token_params[:error].present?
-				return { error: token_params[:error], status: :internal_server_error }
+				return { error: token_params[:error] }, status: :internal_server_error
 			end
 			user.update_access_token(token_params[:access_token])
 

--- a/app/validators/shift_validator.rb
+++ b/app/validators/shift_validator.rb
@@ -1,13 +1,13 @@
 require "date"
 
 class ShiftValidator
-	def initialize(shift, user)
+	def initialize(shift, shift_submission_request_id)
 		@shift = shift
-		@user = user
+	@shift_submission_request_id = shift_submission_request_id
 	end
 
 	def validate
-		validate_date_range
+		validate_date_range if @shift_submission_request_id.present?
 		validate_time
 		raise ActiveRecord::RecordInvalid.new(@shift) unless @shift.errors.empty?
 	end
@@ -15,18 +15,26 @@ class ShiftValidator
 	private
 
 	def validate_date_range
-		shift_membership = @user.memberships.current.first
-		shift_request = ShiftSubmissionRequest.find_by(store_id: shift_membership.store_id)
+	shift_request = ShiftSubmissionRequest.find_by(id: @shift_submission_request_id)
+	if shift_request && @shift.shift_date
+		# 登録予定のシフト時間
 		reg_date = @shift.shift_date.strftime('%Y-%m-%d')
 
-		if !shift_request || Date.parse(reg_date) < shift_request.start_date || Date.parse(reg_date) > shift_request.end_date
-			@shift.errors.add(:shift_date, I18n.t("shift.preferred_shifts.create.out_of_range"))
+		if shift_request.start_date > Date.parse(reg_date) || shift_request.end_date < Date.parse(reg_date)
+		@shift.errors.add(:shift_date, I18n.t("shift.preferred_shifts.create.out_of_range"))
 		end
+	else
+		@shift.errors.add(:shift_date, I18n.t("shift.preferred_shifts.create.no_shift_request"))
+	end
 	end
 
 	def validate_time
-		if @shift.start_time > @shift.end_time
-			@shift.errors.add(:start_time, I18n.t("preferred_shifts.create.invalid_time"))
+		if @shift.start_time && @shift.end_time
+			if @shift.start_time > @shift.end_time
+				@shift.errors.add(:start_time, I18n.t("preferred_shifts.create.invalid_time"))
+			end
+		else
+			@shift.errors.add(:start_time, I18n.t("preferred_shifts.create.missing_time"))
 		end
 	end
 end

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -29,6 +29,13 @@ ja:
         failure: "希望シフトの登録に失敗しました"
         invalid_time: "時間が無効です"
         out_of_range: "時間が範囲外です"
+        no_shift_request: "シフト提出依頼がありません"
+        no_membership: "所属情報がありません"
+        missing_time: "時間が指定されていません"
+    draft_shifts:
+      create:
+        success: "シフトを作成しました"
+        no_privilege: "権限がありません"
   store:
     stores:
       create:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,8 @@ Rails.application.routes.draw do
 		get '/fetch_shift_request', to: 'shift_submission_requests#wanted'
 
 		get '/fetch_shifts', to: 'shifts#fetch_shifts'
+
+		post '/register_draft_shifts', to: 'draft_shifts#create'
 	end
 
 	namespace 'store' do

--- a/spec/controllers/shift/draft_shifts_controller_spec.rb
+++ b/spec/controllers/shift/draft_shifts_controller_spec.rb
@@ -1,0 +1,86 @@
+require 'rails_helper'
+
+RSpec.describe Shift::PreferredShiftsController, type: :controller do
+	describe 'POST #create' do
+		let(:user) { create(:user) }
+		let!(:membership) { create(:membership, user: user, current_store: true) }
+		let(:token) { Jwt::TokenProvider.call(user.id) }
+		let(:store) { create(:store) }
+		let(:shift_submission_request) { create(:shift_submission_request, store: store) }
+		let(:params) {{
+			preferredShifts: [
+				{shift_submission_request_id: shift_submission_request.id, date: date, start_time: start_time, end_time: end_time, notes: notes, is_registered: false}
+			]
+		}}
+
+		let(:date) { Date.today }
+		let(:start_time) { Time.parse('09:00:00') }
+		let(:end_time) { Time.parse('18:00:00') }
+		let(:notes) { 'test note' }
+
+		let(:shift_request) { build(:shift_submission_request, store_id: membership.store_id, start_date: Date.yesterday, end_date: Date.tomorrow) }
+
+		before do
+			allow(ShiftSubmissionRequest).to receive(:find_by).and_return(shift_request)
+		end
+
+		context 'with valid attributes' do
+			before do
+				request.headers['Authorization'] = "Bearer #{token}"
+			end
+
+			context 'when the date is a single' do
+				it 'is valid and adds a new registered shift' do
+					post :create, params: params
+					expect(response).to have_http_status(200)
+				end
+
+				it 'is valid and note is nil' do
+					modified_params = params.deep_dup
+					modified_params[:preferredShifts][0][:notes] = nil
+					post :create, params: modified_params
+					expect(response).to have_http_status(200)
+				end
+			end
+
+			context 'when dates are multiple' do
+				let(:params) {{
+					preferredShifts: [
+						{shift_submission_request_id: shift_submission_request.id, date: date, start_time: start_time, end_time: end_time, notes: notes, is_registered: false},
+						{shift_submission_request_id: shift_submission_request.id, date: date, start_time: start_time, end_time: end_time, notes: notes, is_registered: false},
+						{shift_submission_request_id: shift_submission_request.id, date: date, start_time: start_time, end_time: end_time, notes: notes, is_registered: false}
+					]
+				}}
+
+				it 'is valid and adds a new preferred shift' do
+					post :create, params: params
+					expect(response).to have_http_status(200)
+				end
+			end
+		end
+
+		context 'with invalid attributes' do
+			before do
+				request.headers['Authorization'] = "Bearer #{token}"
+			end
+
+			context 'when setting incorrect date' do
+				let(:date) { Date.parse('2026-01-07') }
+				it 'is not valid and adds an error on shift_date' do
+					post :create, params: params
+					expect(response).to have_http_status(400)
+				end
+			end
+
+			context 'when setting incorrect time' do
+				let(:start_time) { Time.parse('18:00:00') }
+				let(:end_time) { Time.parse('09:00:00') }
+
+				it 'is not valid and adds an error on start_time' do
+					post :create, params: params
+					expect(response).to have_http_status(400)
+				end
+			end
+		end
+	end
+end

--- a/spec/controllers/shift/preferred_shifts_controller_spec.rb
+++ b/spec/controllers/shift/preferred_shifts_controller_spec.rb
@@ -9,13 +9,20 @@ RSpec.describe Shift::PreferredShiftsController, type: :controller do
 		let(:shift_submission_request) { create(:shift_submission_request, store: store) }
 		let(:params) {{
 			preferredShifts: [
-				{shift_submission_request_id: shift_submission_request.id, date: date, startTime: startTime, endTime: endTime, notes: notes}
+				{
+					shift_submission_request_id: shift_submission_request.id,
+					date: date,
+					start_time: start_time,
+					end_time: end_time,
+					notes: notes,
+					is_registered: false
+				}
 			]
 		}}
 
 		let(:date) { Date.today }
-		let(:startTime) { Time.parse('09:00:00') }
-		let(:endTime) { Time.parse('18:00:00') }
+		let(:start_time) { Time.parse('09:00:00') }
+		let(:end_time) { Time.parse('18:00:00') }
 		let(:notes) { 'test note' }
 
 		let(:shift_request) { build(:shift_submission_request, store_id: membership.store_id, start_date: Date.yesterday, end_date: Date.tomorrow) }
@@ -46,9 +53,9 @@ RSpec.describe Shift::PreferredShiftsController, type: :controller do
 			context 'when dates are multiple' do
 				let(:params) {{
 					preferredShifts: [
-						{shift_submission_request_id: shift_submission_request.id, date: date, startTime: startTime, endTime: endTime, notes: notes},
-						{shift_submission_request_id: shift_submission_request.id, date: date, startTime: startTime, endTime: endTime, notes: notes},
-						{shift_submission_request_id: shift_submission_request.id, date: date, startTime: startTime, endTime: endTime, notes: notes}
+						{shift_submission_request_id: shift_submission_request.id, date: date, start_time: start_time, end_time: end_time, notes: notes, is_registered: false},
+						{shift_submission_request_id: shift_submission_request.id, date: date, start_time: start_time, end_time: end_time, notes: notes, is_registered: false},
+						{shift_submission_request_id: shift_submission_request.id, date: date, start_time: start_time, end_time: end_time, notes: notes, is_registered: false}
 					]
 				}}
 
@@ -73,10 +80,10 @@ RSpec.describe Shift::PreferredShiftsController, type: :controller do
 			end
 
 			context 'when setting incorrect time' do
-				let(:startTime) { Time.parse('18:00:00') }
-				let(:endTime) { Time.parse('09:00:00') }
+				let(:start_time) { Time.parse('18:00:00') }
+				let(:end_time) { Time.parse('09:00:00') }
 
-				it 'is not valid and adds an error on startTime' do
+				it 'is not valid and adds an error on start_time' do
 					post :create, params: params
 					expect(response).to have_http_status(400)
 				end


### PR DESCRIPTION
## 概要
登録予定シフトを追加する処理の追加とシフト関連の処理修正を行いました．


## 変更点
- 登録予定シフト追加
- shift_submission_request_idを任意に
- シフトの保存をモデルにまとめる
- ステータスコード調整
- 希望シフトのファットコントローラ解消


## 影響範囲
- 希望シフト作成
- 登録予定シフト作成


## 動作要件
- [ ] いつも通り，docker-compose upで可能


## テスト
- RSpec実行


## 関連Issue
- なし


## 補足
- なし