### PR TITLE
[Add]Auth.js認証追加

### DIFF
--- a/app/controllers/shift/draft_shifts_controller.rb
+++ b/app/controllers/shift/draft_shifts_controller.rb
@@ -1,14 +1,18 @@
 class Shift::DraftShiftsController < ApplicationController
-	before_action :authenticate, only: [:create]
-
 	def create
-		if @current_user.memberships.current.first.privilege == "staff"
+		login_user = User.find_by(email: input_params[:email]).first
+		if login_user.nil?
+			render json: { error: "ユーザが見つかりません" }, status: :not_found
+			return
+		end
+
+		if login_user.privilege == "staff"
 			render json: { error: I18n.t('shift.draft_shifts.create.no_privilege') }, status: :bad_request
 			return
 		end
 
 		begin
-			Shift.register_draft_shifts!(input_params, @current_user)
+			Shift.register_draft_shifts!(input_params, login_user)
 			render json: { message: I18n.t('shift.draft_shifts.create.success') }, status: :ok
 		rescue ActiveRecord::RecordInvalid => e
 			render json: { error: e.message }, status: :bad_request
@@ -18,6 +22,7 @@ class Shift::DraftShiftsController < ApplicationController
 	private
 
 	def input_params
+		params.permit(:email)
 		params.require(:draft_shifts).map do |shift|
 			shift.permit(:id, :user_name, :date, :start_time, :end_time, :notes, :is_registered, :shift_submission_request_id)
 		end

--- a/app/controllers/shift/preferred_shifts_controller.rb
+++ b/app/controllers/shift/preferred_shifts_controller.rb
@@ -1,10 +1,9 @@
 class Shift::PreferredShiftsController < ApplicationController
-	before_action :authenticate, only: [:create]
-
 	def create
 		begin
-			Shift.register_preferred_shifts!(input_params, @current_user)
-			render json: { msg: I18n.t('shift.preferred_shifts.create.success') }, status: :ok
+			login_user = User.find_by(email: params[:email])
+			Shift.register_preferred_shifts!(input_params, login_user)
+			render json: { message: I18n.t('shift.preferred_shifts.create.success') }, status: :ok
 		rescue ActiveRecord::RecordInvalid => e
 			render json: { error: e.message }, status: :bad_request
 		end
@@ -14,7 +13,7 @@ class Shift::PreferredShiftsController < ApplicationController
 
 	def input_params
 		params.require(:preferredShifts).map do |shift|
-			shift.permit(:shift_submission_request_id, :date, :start_time, :end_time, :notes, :is_registered)
+			shift.permit(:shift_submission_request_id, :date, :start_time, :end_time, :notes, :is_registered, :email)
 		end
 	end
 end

--- a/app/controllers/shift/shifts_controller.rb
+++ b/app/controllers/shift/shifts_controller.rb
@@ -1,48 +1,59 @@
 class Shift::ShiftsController < ApplicationController
-	before_action :authenticate, only: [:fetch_shifts]
-
 	# 店舗全員のシフト取得
 	def fetch_shifts
-		login_store = Membership.with_users(@current_user.id).current
-		if login_store.none?
-			render json: { error: I18n.t('shift.shifts.fetch_shifts.login_required') }, status: :not_found
+		if input_params[:email].blank?
+			render json: { error: I18n.t('errors.messages.email_blank') }, status: :bad_request
 			return
 		end
 
-		# 店舗のスタッフ一覧取得
-		staff_memberships = Membership.with_stores(login_store[0].store_id)
-								.select(:id, :user_id, :privilege)
-								.includes(:user)
-
-		# 全シフト情報取得
-		staff_shift_list = staff_memberships.map do |staff|
-			staff_shifts = Shift.where(shift_date: input_params['start_date']..input_params['end_date'])
-
-			staff_shifts.map do |shift|
-				# スタッフは希望シフト情報を閲覧できない
-				if login_store[0].privilege == "staff" && !shift.is_registered || shift.membership_id != staff.id
-					next
-				end
-
-				{
-					id: shift.id,
-					user_name: staff.user.user_name,
-					date: shift.shift_date,
-					start_time: shift.start_time,
-					end_time: shift.end_time,
-					notes: shift.notes,
-					is_registered: shift.is_registered,
-					shift_submission_request_id: shift.shift_submission_request_id
-				}
-			end.compact
+		user = User.find_by(email: input_params[:email])
+		if user.nil?
+			render json: { error: I18n.t('errors.messages.user_not_found') }, status: :not_found
+			return
 		end
+
+		current_membership = Membership.find_by(user_id: user.id, current_store: true)
+		if current_membership.nil?
+			render json: { error: I18n.t('errors.messages.store_not_found') }, status: :not_found
+			return
+		end
+
+		staff_shift_list = fetch_staff_shift_list(current_membership, input_params[:start_date], input_params[:end_date])
 
 		render json: { staff_shift_list: staff_shift_list }, status: :ok
 	end
 
 	private
 
+	def fetch_staff_shift_list(membership, start_date, end_date)
+		Membership.with_stores(membership.store_id)
+				.select(:id, :user_id, :privilege)
+				.includes(:user)
+				.map do |staff|
+			Shift.where(shift_date: start_date..end_date)
+				.select { |shift| can_view_shift?(membership, staff, shift) }
+				.map { |shift| shift_data(staff, shift) }
+		end
+	end
+
+	def can_view_shift?(membership, staff, shift)
+		(membership.privilege == 'manager' || shift.is_registered) && shift.membership_id == staff.id
+	end
+
+	def shift_data(staff, shift)
+		{
+			id: shift.id,
+			user_name: staff.user.user_name,
+			date: shift.shift_date,
+			start_time: shift.start_time,
+			end_time: shift.end_time,
+			notes: shift.notes,
+			is_registered: shift.is_registered,
+			shift_submission_request_id: shift.shift_submission_request_id
+		}
+	end
+
 	def input_params
-		params.require(:fetch_shift).permit(:start_date, :end_date)
+		params.require(:fetch_shift).permit(:start_date, :end_date, :email)
 	end
 end

--- a/app/controllers/shift/shifts_controller.rb
+++ b/app/controllers/shift/shifts_controller.rb
@@ -25,17 +25,16 @@ class Shift::ShiftsController < ApplicationController
 
 	private
 
+	# 店舗に所属するスタッフのシフト情報抽出
 	def fetch_staff_shift_list(membership, start_date, end_date)
-		Membership.with_stores(membership.store_id)
-				.select(:id, :user_id, :privilege)
-				.includes(:user)
-				.map do |staff|
+		Membership.with_stores(membership.store_id).select(:id, :user_id, :privilege).includes(:user).map do |staff|
 			Shift.where(shift_date: start_date..end_date)
 				.select { |shift| can_view_shift?(membership, staff, shift) }
 				.map { |shift| shift_data(staff, shift) }
 		end
 	end
 
+	# 管理者か登録済シフトなら取得
 	def can_view_shift?(membership, staff, shift)
 		(membership.privilege == 'manager' || shift.is_registered) && shift.membership_id == staff.id
 	end
@@ -43,7 +42,7 @@ class Shift::ShiftsController < ApplicationController
 	def shift_data(staff, shift)
 		{
 			id: shift.id,
-			user_name: staff.user.user_name,
+			email: staff.user.email,
 			date: shift.shift_date,
 			start_time: shift.start_time,
 			end_time: shift.end_time,

--- a/app/controllers/store/store_controller.rb
+++ b/app/controllers/store/store_controller.rb
@@ -1,5 +1,5 @@
 class Store::StoreController < ApplicationController
-	before_action :authenticate, only: [:create, :fetch_staff_list]
+	before_action :authenticate, only: [:create]
 
 	def create
 		store = Store.new(
@@ -30,13 +30,24 @@ class Store::StoreController < ApplicationController
 	end
 
 	def fetch_staff_list
-		login_store = Membership.with_users(@current_user.id).current
-		if login_store.none?
+		email = params[:email]
+		if email == "undefined"
+			render json: { error: "emailがありません" }, status: :bad_request
+			return
+		end
+		login_user = User.find_by(email: email)
+		if login_user.nil?
+			render json: { error: "ユーザが見つかりません" }, status: :not_found
+			return
+		end
+
+		login_store = Membership.find_by(user_id: login_user.id, current_store: true)
+		if login_store.nil?
 			render json: { error: I18n.t('store.stores.fetch_staff_list.not_found') }, status: :not_found
 			return
 		end
 
-		staff_memberships = Membership.with_stores(login_store[0].store_id)
+		staff_memberships = Membership.with_stores(login_store.store_id)
 										.select(:id, :user_id, :privilege)
 										.includes(:user)
 

--- a/app/controllers/store/store_controller.rb
+++ b/app/controllers/store/store_controller.rb
@@ -1,6 +1,4 @@
 class Store::StoreController < ApplicationController
-	before_action :authenticate, only: [:create]
-
 	def create
 		store = Store.new(
 			store_name: input_store_params[:store_name],
@@ -14,11 +12,12 @@ class Store::StoreController < ApplicationController
 			return
 		end
 
-		begin
+		ActiveRecord::Base.transaction do
+			login_user = User.find_by(email: input_store_params[:email])
 			store.save!
 			# 店舗作成者は権限2に設定
 			Membership.create!(
-				user_id: @current_user.id,
+				user_id: login_user.id,
 				store_id: store.id,
 				current_store: true,
 				privilege: 2
@@ -61,6 +60,6 @@ class Store::StoreController < ApplicationController
 	private
 
 	def input_store_params
-		params.require(:store).permit(:store_name, :location)
+		params.permit(:store_name, :location, :email)
 	end
 end

--- a/app/controllers/store/store_controller.rb
+++ b/app/controllers/store/store_controller.rb
@@ -51,7 +51,13 @@ class Store::StoreController < ApplicationController
 										.includes(:user)
 
 		staff_list = staff_memberships.map do |staff|
-			{ id: staff.id, privilege: staff.privilege, user_name: staff.user.user_name }
+			{
+				id: staff.id,
+				privilege: staff.privilege,
+				user_name: staff.user.user_name,
+				email: staff.user.email,
+				picture: staff.user.picture
+			}
 		end
 
 		render json: { staff_list: staff_list }, status: :ok

--- a/app/controllers/user/users_controller.rb
+++ b/app/controllers/user/users_controller.rb
@@ -2,9 +2,9 @@ class User::UsersController < ApplicationController
 	before_action :authenticate, only: [:get_user_info]
 
 	def create
-		result = UserService.create_with_token(input_token_params, input_invitation_params)
+		result = UserService.create_with_token(input_params)
 		if result[:success?]
-			render json: { msg: result[:msg], token: result[:token], user_id: result[:user_id], is_new_user: result[:is_new_user] }, status: :ok
+			render json: { message: result[:message], is_affiliated: result[:is_affiliated] }, status: :ok
 		else
 			render json: { error: result[:error] }, status: :unprocessable_entity
 		end
@@ -20,11 +20,7 @@ class User::UsersController < ApplicationController
 
 	private
 
-	def input_token_params
-		params.permit(:code)
-	end
-
-	def input_invitation_params
-		params.permit(:invitation_id)
+	def input_params
+		params.permit(:code, :invitation_id, user: [:id, :name, :email, :picture])
 	end
 end

--- a/app/controllers/user/users_controller.rb
+++ b/app/controllers/user/users_controller.rb
@@ -1,6 +1,4 @@
 class User::UsersController < ApplicationController
-	before_action :authenticate, only: [:get_user_info]
-
 	def create
 		result = UserService.create_with_token(input_params)
 		if result[:success?]
@@ -11,10 +9,11 @@ class User::UsersController < ApplicationController
 	end
 
 	def get_user_info
-		if @current_user
-			render json: { user: @current_user }
+		login_user = User.find_by(email: input_user_params[:email])
+		if login_user.nil?
+			render json: { error: I18n.t('user.users.get_user_info.failed') }, status: :bad_request
 		else
-			render json: { error: I18n.t('user.users.get_user_info.failed') }, status: bad_request
+			render json: { user: login_user }
 		end
 	end
 
@@ -22,5 +21,9 @@ class User::UsersController < ApplicationController
 
 	def input_params
 		params.permit(:code, :invitation_id, user: [:id, :name, :email, :picture])
+	end
+
+	def input_user_params
+		params.permit(:email)
 	end
 end

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -10,20 +10,22 @@ class Shift < ApplicationRecord
 	scope :with_id, ->(id) { where(id: id) }
 	scope :registered_shift_for_date, ->(membership_id, shift_date) { where(membership_id: membership_id, shift_date: shift_date, is_registered: true) }
 
-	def self.register_draft_shifts!(shifts_params, current_user)
-		register_shifts!(shifts_params, current_user, true)
+	# 本登録シフト
+	def self.register_draft_shifts!(shifts_params, login_user)
+		register_shifts!(shifts_params, login_user, true)
 	end
 
-	def self.register_preferred_shifts!(shifts_params, current_user)
-		register_shifts!(shifts_params, current_user, false)
+	# 仮登録シフト
+	def self.register_preferred_shifts!(shifts_params, login_user)
+		register_shifts!(shifts_params, login_user, false)
 	end
 
 	private
 
-	def self.register_shifts!(shifts_params, current_user, is_draft_shifts)
+	def self.register_shifts!(shifts_params, login_user, is_draft_shifts)
 		ActiveRecord::Base.transaction do
 			shifts_params.each do |shift_params|
-				membership_id = find_membership_id(shift_params, current_user, is_draft_shifts)
+				membership_id = find_membership_id(shift_params, login_user, is_draft_shifts)
 				raise ActiveRecord::RecordInvalid.new("Membership not found") if membership_id.nil?
 
 				shift = build_shift(shift_params, membership_id)

--- a/app/services/user_service.rb
+++ b/app/services/user_service.rb
@@ -1,42 +1,22 @@
 class UserService
-	def self.create_with_token(input_token_params, invitation_id = nil)
-		# GoogleAccessToken取得
-		token_service = TokenService.new(input_token_params)
-		token_params = token_service.get_token
+	def self.create_with_token(input_params)
+		invitation_id = input_params[:invitation_id] || nil
 
-		return { success?: false, error: token_params[:error] } if token_params[:error].present?
-
-		@token = Token.new(
-			refresh_token: token_params[:refresh_token],
-			access_token: token_params[:access_token]
-		)
-
-		# Googleアカウント情報取得
-		user_params = Google::GoogleService.fetch_user_info(@token.access_token)
-		return { success?: false, error: user_params[:error] } if user_params[:error].present?
-
-		user = User.find_or_initialize_by(email: user_params[:email])
-
-		# 店舗に所属していないユーザ
-		is_new_user = true
+		user = User.find_or_initialize_by(email: input_params[:user][:email])
 
 		# 既存ユーザの場合
 		if user.persisted?
-			user.update_access_token(@token.access_token)
-			memberships = Membership.current.with_users(user.id)
-			is_new_user = false if memberships.count > 0
-			token = Jwt::TokenProvider.call(user.id)
-			{ success?: true, msg: I18n.t('user.users.create.already_created'), token: token, user_id: user.id, is_new_user: is_new_user }
+			# 店舗に所属しているか
+			is_affiliated = Membership.current.with_users(user.id).count > 0
+			{ success?: true, message: I18n.t('user.users.create.already_created'), is_affiliated: is_affiliated }
 		else
-			# ユーザの保存とJWTトークンの生成
-			if user.update(user_params)
+			# ユーザの保存
+			if user.update(input_params[:user])
 				begin
 					Membership.create_with_invitation(invitation_id[:invitation_id], user.id) if invitation_id[:invitation_id].present?
-					memberships = Membership.current.with_users(user.id)
-					is_new_user = false if memberships.count > 0
-					user.create_token(@token.refresh_token, @token.access_token)
-					token = Jwt::TokenProvider.call(user.id)
-					{ success?: true, msg: I18n.t('user.users.create.success'), token: token, user_id: user.id, is_new_user: is_new_user }
+					# 店舗に所属しているか
+					is_affiliated = Membership.current.with_users(user.id).count > 0
+					{ success?: true, message: I18n.t('user.users.create.success'), is_affiliated: is_affiliated }
 				rescue StandardError => e
 					{ success?: false, error: e }
 				end

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -10,8 +10,8 @@ ja:
   user:
     users:
       create:
-        already_created: "ユーザは既に作成済みです"
-        success: "ユーザを作成しました"
+        already_created: "お帰りなさい"
+        success: "minshifへ、ようこそ"
       get_user_info:
         failed: "ユーザが見つかりませんでした"
   shift:

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -7,6 +7,10 @@ ja:
       past_date: "過去の日付は選択できません"
       start_date_after_end_date: "開始日時は終了日時より後の日時を選択してください"
       deadline_date_after_end_date: "締切日時は終了日時より後の日時を選択してください"
+      messages:
+        email_blank: "メールアドレスを入力してください"
+        user_not_found: "ユーザが見つかりませんでした"
+        store_not_found: "店舗が見つかりませんでした"
   user:
     users:
       create:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
 	namespace 'user' do
 		post '/create', to: 'users#create'
-		post '/get_user_info', to: 'users#get_user_info'
+		get '/get_user_info', to: 'users#get_user_info'
 	end
 
 	namespace 'shift' do

--- a/spec/controllers/shift/draft_shifts_controller_spec.rb
+++ b/spec/controllers/shift/draft_shifts_controller_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Shift::PreferredShiftsController, type: :controller do
 		let(:store) { create(:store) }
 		let(:shift_submission_request) { create(:shift_submission_request, store: store) }
 		let(:params) {{
+			email: user.email,
 			preferredShifts: [
 				{shift_submission_request_id: shift_submission_request.id, date: date, start_time: start_time, end_time: end_time, notes: notes, is_registered: false}
 			]
@@ -45,6 +46,7 @@ RSpec.describe Shift::PreferredShiftsController, type: :controller do
 
 			context 'when dates are multiple' do
 				let(:params) {{
+					email: user.email,
 					preferredShifts: [
 						{shift_submission_request_id: shift_submission_request.id, date: date, start_time: start_time, end_time: end_time, notes: notes, is_registered: false},
 						{shift_submission_request_id: shift_submission_request.id, date: date, start_time: start_time, end_time: end_time, notes: notes, is_registered: false},

--- a/spec/controllers/shift/preferred_shifts_controller_spec.rb
+++ b/spec/controllers/shift/preferred_shifts_controller_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe Shift::PreferredShiftsController, type: :controller do
 	describe 'POST #create' do
 		let(:user) { create(:user) }
 		let!(:membership) { create(:membership, user: user, current_store: true) }
-		let(:token) { Jwt::TokenProvider.call(user.id) }
 		let(:store) { create(:store) }
 		let(:shift_submission_request) { create(:shift_submission_request, store: store) }
 		let(:params) {{
+			email: user.email,
 			preferredShifts: [
 				{
 					shift_submission_request_id: shift_submission_request.id,
@@ -32,10 +32,6 @@ RSpec.describe Shift::PreferredShiftsController, type: :controller do
 		end
 
 		context 'with valid attributes' do
-			before do
-				request.headers['Authorization'] = "Bearer #{token}"
-			end
-
 			context 'when the date is a single' do
 				it 'is valid and adds a new preferred shift' do
 					post :create, params: params
@@ -52,6 +48,7 @@ RSpec.describe Shift::PreferredShiftsController, type: :controller do
 
 			context 'when dates are multiple' do
 				let(:params) {{
+					email: user.email,
 					preferredShifts: [
 						{shift_submission_request_id: shift_submission_request.id, date: date, start_time: start_time, end_time: end_time, notes: notes, is_registered: false},
 						{shift_submission_request_id: shift_submission_request.id, date: date, start_time: start_time, end_time: end_time, notes: notes, is_registered: false},
@@ -67,10 +64,6 @@ RSpec.describe Shift::PreferredShiftsController, type: :controller do
 		end
 
 		context 'with invalid attributes' do
-			before do
-				request.headers['Authorization'] = "Bearer #{token}"
-			end
-
 			context 'when setting incorrect date' do
 				let(:date) { Date.parse('2026-01-07') }
 				it 'is not valid and adds an error on shift_date' do

--- a/spec/controllers/shift/shifts_controller_spec.rb
+++ b/spec/controllers/shift/shifts_controller_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Shift::ShiftsController, type: :controller do
 						'date' => '2024-08-15',
 						'start_time' => '2000-01-01T09:00:00.000+09:00',
 						'end_time' => '2000-01-01T18:00:00.000+09:00',
-						'user_name' => user.user_name,
+						'email' => user.email,
 						'is_registered' => false
 					)
 				end

--- a/spec/controllers/shift/shifts_controller_spec.rb
+++ b/spec/controllers/shift/shifts_controller_spec.rb
@@ -11,19 +11,20 @@ RSpec.describe Shift::ShiftsController, type: :controller do
 		context "with valid attributes" do
 			context 'requested by the manager' do
 				let(:store) { create(:store) }
-				let!(:membership) { create(:membership, user: user, store: store, privilege: 2) }
+				let!(:membership) { create(:membership, user: user, store: store, privilege: 2, current_store: true) }
 				let(:shift_submission_request) { create(:shift_submission_request) }
 				let!(:shift1) { create(:shift, membership: membership, shift_submission_request: shift_submission_request, shift_date: '2024-08-15') }
 				let!(:shift2) { create(:shift, membership: membership, shift_submission_request: shift_submission_request, shift_date: '2024-08-20') }
 
 				let(:params) {{
 					fetch_shift: {
+						email: user.email,
 						start_date: Date.parse("2024-08-01"),
 						end_date: Date.parse("2024-08-30"),
 					}
 				}}
 
-				it "return correct staff list" do
+				it "returns correct staff list" do
 					get :fetch_shifts, params: params
 					expect(response).to have_http_status(:success)
 
@@ -32,36 +33,37 @@ RSpec.describe Shift::ShiftsController, type: :controller do
 					expect(staff_list).to be_an(Array)
 					expect(staff_list.first).to include(
 						'date' => '2024-08-15',
-						"start_time"=>"2000-01-01T09:00:00.000+09:00",
-						"end_time"=>"2000-01-01T18:00:00.000+09:00",
+						'start_time' => '2000-01-01T09:00:00.000+09:00',
+						'end_time' => '2000-01-01T18:00:00.000+09:00',
 						'user_name' => user.user_name,
-						'is_registered'=>false
+						'is_registered' => false
 					)
 				end
 			end
 
 			context 'requested by the staff' do
 				let(:store) { create(:store) }
-				let!(:membership) { create(:membership, user: user, store: store, privilege: 1) }
+				let!(:membership) { create(:membership, user: user, store: store, privilege: 1, current_store: true) }
 				let(:shift_submission_request) { create(:shift_submission_request) }
 				let!(:shift1) { create(:shift, membership: membership, shift_submission_request: shift_submission_request, shift_date: '2024-08-15') }
 				let!(:shift2) { create(:shift, membership: membership, shift_submission_request: shift_submission_request, shift_date: '2024-08-20') }
 
 				let(:params) {{
 					fetch_shift: {
+						email: user.email,
 						start_date: Date.parse("2024-08-01"),
 						end_date: Date.parse("2024-08-30"),
 					}
 				}}
 
-				it "return nil staff list" do
+				it "returns nil staff list" do
 					get :fetch_shifts, params: params
 					expect(response).to have_http_status(:success)
 
 					staff_list = JSON.parse(response.body)['staff_shift_list'][0]
 
 					expect(staff_list).to be_an(Array)
-					expect(staff_list.first).to be nil
+					expect(staff_list.first).to be_nil
 				end
 			end
 		end
@@ -69,16 +71,38 @@ RSpec.describe Shift::ShiftsController, type: :controller do
 		context "with invalid attributes" do
 			let(:params) {{
 				fetch_shift: {
+					email: "",
 					start_date: Date.parse("2024-08-01"),
 					end_date: Date.parse("2024-08-30"),
 				}
 			}}
 
-			it "had not logged in to the shop" do
+			it "returns email missing error" do
 				get :fetch_shifts, params: params
 
 				expect(JSON.parse(response.body)).to eq({
-					"error"	=> I18n.t('shift.shifts.fetch_shifts.login_required')
+					"error" => I18n.t('errors.messages.email_blank')
+				})
+				expect(response).to have_http_status(:bad_request)
+			end
+
+			it "returns user not found error" do
+				params[:fetch_shift][:email] = "nonexistent@example.com"
+				get :fetch_shifts, params: params
+
+				expect(JSON.parse(response.body)).to eq({
+					"error" => I18n.t('errors.messages.user_not_found')
+				})
+				expect(response).to have_http_status(:not_found)
+			end
+
+			it "returns store not found error" do
+				allow(Membership).to receive(:find_by).and_return(nil)
+				params[:fetch_shift][:email] = user.email
+				get :fetch_shifts, params: params
+
+				expect(JSON.parse(response.body)).to eq({
+					"error" => I18n.t('errors.messages.store_not_found')
 				})
 				expect(response).to have_http_status(:not_found)
 			end

--- a/spec/controllers/store/store_controller_spec.rb
+++ b/spec/controllers/store/store_controller_spec.rb
@@ -83,6 +83,8 @@ RSpec.describe Store::StoreController, type: :controller do
 				expect(staff_list.first).to include(
 					'id' => membership.id,
 					'user_name' => user.user_name,
+					'email' => user.email,
+					'picture' => user.picture,
 					'privilege' => 'staff'
 				)
 			end

--- a/spec/controllers/store/store_controller_spec.rb
+++ b/spec/controllers/store/store_controller_spec.rb
@@ -72,8 +72,8 @@ RSpec.describe Store::StoreController, type: :controller do
 			let(:store) { create(:store) }
 			let!(:membership) { create(:membership, user: user, store: store, current_store: true) }
 
-			it "return correct staff list" do
-				get :fetch_staff_list
+			it "returns correct staff list" do
+				get :fetch_staff_list, params: { email: user.email }
 				expect(response).to have_http_status(:success)
 				staff_list = JSON.parse(response.body)['staff_list']
 
@@ -87,8 +87,8 @@ RSpec.describe Store::StoreController, type: :controller do
 		end
 
 		context "with invalid attributes" do
-			it "had not logged in to the shop" do
-				get :fetch_staff_list
+			it "returns error when user is not logged in to the shop" do
+				get :fetch_staff_list, params: { email: user.email }
 
 				expect(JSON.parse(response.body)).to eq({
 					"error"	=> I18n.t('store.stores.fetch_staff_list.not_found')

--- a/spec/controllers/store/store_controller_spec.rb
+++ b/spec/controllers/store/store_controller_spec.rb
@@ -3,10 +3,9 @@ require 'rails_helper'
 RSpec.describe Store::StoreController, type: :controller do
 	describe 'POST #create' do
 		let(:input_store_params) {{
-			store: {
-				store_name: store_name,
-				location: '木ノ葉隠れの里',
-			}
+			email: @current_user.email,
+			store_name: store_name,
+			location: '木ノ葉隠れの里',
 		}}
 
 		before(:each) do
@@ -45,7 +44,10 @@ RSpec.describe Store::StoreController, type: :controller do
 		context "when store already exists" do
 			let(:store_name) { "ラーメン一楽" }
 			before do
-				Store.create!(input_store_params[:store])
+				Store.create!(
+					store_name: input_store_params[:store_name],
+					location: input_store_params[:location]
+				)
 			end
 
 			it "does not allow duplicate store names" do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -2,17 +2,23 @@ require 'rails_helper'
 
 RSpec.describe User::UsersController, type: :controller do
 	describe "POST #create" do
-		let(:input_params) { { code: 'sample_code' } }
+		let(:input_params) { {
+			code: '',
+			invitation_id: '',
+			user: {
+				user_name: "test",
+				email: "test@gmail.com",
+				picture: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSYS_ocSphOFHVuKC9WgglMIvN44YC0op4uJ5rZ-qjcVhMJmwbYnudOngqiHLMTgb_kfr0"
+			}
+		} }
 
 		context "when the new user create is successful" do
 			before do
 				allow(UserService).to receive(:create_with_token).and_return(
 					success?: true,
-					msg: I18n.t('user.users.create.success'),
-					token: 'sample_token',
-					user_id: '1',
-					is_new_user: true,
-					status: :created
+					message: I18n.t('user.users.create.success'),
+					is_affiliated: true,
+					success?: :true
 				)
 			end
 
@@ -20,10 +26,8 @@ RSpec.describe User::UsersController, type: :controller do
 				post :create, params: input_params
 				expect(response).to have_http_status(200)
 				expect(JSON.parse(response.body)).to eq({
-					"msg"			=> I18n.t('user.users.create.success'),
-					"token"			=> "sample_token",
-					"user_id"		=> "1",
-					"is_new_user"	=> true
+					"message"		=> I18n.t('user.users.create.success'),
+					"is_affiliated"	=> true
 				})
 			end
 		end
@@ -32,11 +36,8 @@ RSpec.describe User::UsersController, type: :controller do
 			before do
 				allow(UserService).to receive(:create_with_token).and_return(
 					success?: true,
-					msg: I18n.t('user.users.create.already_created'),
-					token: 'sample_token',
-					user_id: '1',
-					is_new_user: false,
-					status: :ok
+					message: I18n.t('user.users.create.already_created'),
+					is_affiliated: false,
 				)
 			end
 
@@ -44,10 +45,8 @@ RSpec.describe User::UsersController, type: :controller do
 				post :create, params: input_params
 				expect(response).to have_http_status(200)
 				expect(JSON.parse(response.body)).to eq({
-					"msg"			=> I18n.t('user.users.create.already_created'),
-					"token"			=> "sample_token",
-					"user_id"		=> "1",
-					"is_new_user"	=> false
+					"message"		=> I18n.t('user.users.create.already_created'),
+					"is_affiliated"	=> false
 				})
 			end
 		end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -70,16 +70,11 @@ RSpec.describe User::UsersController, type: :controller do
 		end
 	end
 
-	describe 'POST#get_user_info' do
+	describe 'GET#get_user_info' do
 		let(:user) { create(:user) }
-		let(:token) { Jwt::TokenProvider.call(user.id) }
-
-		before do
-			request.headers['Authorization'] = "Bearer #{token}"
-		end
 
 		it 'when the user information is correct' do
-			post :get_user_info
+			get :get_user_info, params: { email: user.email }
 
 			expect(response).to have_http_status(200)
 			expect(JSON.parse(response.body)['user']).to include({
@@ -87,6 +82,15 @@ RSpec.describe User::UsersController, type: :controller do
 				'user_name' => user.user_name,
 				'email' => user.email,
 				'picture' => user.picture
+			})
+		end
+
+		it 'returns an error when the user is not found' do
+			get :get_user_info, params: { email: 'nonexistent@example.com' }
+
+			expect(response).to have_http_status(:bad_request)
+			expect(JSON.parse(response.body)).to include({
+				'error' => I18n.t('user.users.get_user_info.failed')
 			})
 		end
 	end


### PR DESCRIPTION
## 概要
サーバのJWT認証は廃止して，Auth.jsのセッションによる認証へ移行した．


## 変更点
- JWTトークンでuser_idを取得して情報を抽出していたが，emailによって情報を抽出するように変更した．


## 影響範囲
- JWTトークンを使って認証を行っていた機能
    - ユーザ作成
    - 店舗作成
    - シフト作成
    - ユーザコンテキスト
    - トークンコンテキスト
    - シフト提出依頼コンテキスト


## 動作要件
- [ ] 店舗に参加した状態で`/home`にアクセス


## テスト
- 店舗に所属しているスタッフ一覧とシフト情報が取得できる
- テストコードが全てパスする


## 補足
tokenを使う機能が残っているためemailで対応させる移行作業が必要ある