### PR TITLE
[Fix]ShiftSubmissionRequest対応

### DIFF
--- a/app/models/shift_submission_request.rb
+++ b/app/models/shift_submission_request.rb
@@ -9,7 +9,7 @@ class ShiftSubmissionRequest < ApplicationRecord
 	validate :start_date_is_less_than_end_date
 	validate :deadline_is_less_than_start_date
 
-	scope :wanted, ->(store_id) { where('store_id = ? AND deadline_date > ?',  store_id, Date.today) }
+	scope :wanted, ->(store_id) { where('store_id = ? AND deadline_date >= ?',  store_id, Date.today) }
 
 	private
 

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -1,5 +1,5 @@
 ja:
-  defaults:
+  default:
     message:
       require_login: "ログインしてください"
       require_membership: "所属情報が見つかりません"
@@ -47,7 +47,8 @@ ja:
         already_created: "指定された店舗名は既に作成されています"
         empty: "店舗名が登録されていません"
       fetch_staff_list:
-        not_found: "店情報が取得できませんでした"
+        not_found_user: "ユーザが取得できませんでした"
+        not_found_membership: "店情報が取得できませんでした"
   invitation:
     invitations:
       create:


### PR DESCRIPTION
## 概要
Auth.jsによる認証の移行に伴った修正を実施．


## 変更点
- 店舗IDはバックエンドで管理
- JWTをバックエンドで管理せず，emailでユーザ管理
- シフト提出依頼は締切日が今日までのものを取得するよう変更


## 影響範囲
- シフト提出依頼の取得
- 店舗情報の管理


## 動作要件
特になし


## テスト
- シフト提出依頼を正常に作成できる
- 作成済みのシフト提出依頼を正常に取得できる
- テストコードが全てパスする


## 補足
今後テストコードを増やす必要がある．