### PR TITLE
[Fix]提出済みシフト依頼排除

### DIFF
--- a/app/controllers/shift/shift_submission_requests_controller.rb
+++ b/app/controllers/shift/shift_submission_requests_controller.rb
@@ -42,9 +42,14 @@ class Shift::ShiftSubmissionRequestsController < ApplicationController
 			render json: { error: I18n.t('store.stores.fetch_staff_list.not_found') }, status: :not_found
 			return
 		end
+		p "----------dddddd-----------------"
+		p Shift.where(membership_id: login_store.id)
+		p "----------------aaaaa-----------"
+		p Shift.where(membership_id: login_store.id).select(:shift_submission_request_id)
+		p "----------------a-----------"
 
 		# 募集中のシフト提出依頼を取得
-		data = ShiftSubmissionRequest.wanted(login_store.store_id)
+		data = ShiftSubmissionRequest.wanted(login_store)
 		if data
 			render json: { data: data }, status: :ok
 		else

--- a/app/controllers/shift/shift_submission_requests_controller.rb
+++ b/app/controllers/shift/shift_submission_requests_controller.rb
@@ -42,11 +42,6 @@ class Shift::ShiftSubmissionRequestsController < ApplicationController
 			render json: { error: I18n.t('store.stores.fetch_staff_list.not_found') }, status: :not_found
 			return
 		end
-		p "----------dddddd-----------------"
-		p Shift.where(membership_id: login_store.id)
-		p "----------------aaaaa-----------"
-		p Shift.where(membership_id: login_store.id).select(:shift_submission_request_id)
-		p "----------------a-----------"
 
 		# 募集中のシフト提出依頼を取得
 		data = ShiftSubmissionRequest.wanted(login_store)

--- a/app/models/shift_submission_request.rb
+++ b/app/models/shift_submission_request.rb
@@ -9,7 +9,11 @@ class ShiftSubmissionRequest < ApplicationRecord
 	validate :start_date_is_less_than_end_date
 	validate :deadline_is_less_than_start_date
 
-	scope :wanted, ->(store_id) { where('store_id = ? AND deadline_date >= ?',  store_id, Date.today) }
+	scope :wanted, ->(membership) {
+		where('store_id = ? AND deadline_date >= ?', membership.store_id, Date.today)
+		.where.not(id: Shift.where(membership_id: membership.id).where.not(shift_submission_request_id: nil).select(:shift_submission_request_id))
+	}
+
 
 	private
 


### PR DESCRIPTION
## 概要
提出済みのシフト依頼を排除しました．

## 変更点
- すでに提出済みのシフト提出依頼は取得できないようにした


## 影響範囲
- フロントのシフト提出依頼コンテキスト


## テスト
1. `/home`でシフト提出依頼の一覧表示
2. すでに提出済みのものは表示されないようになる．
