### PR TITLE
[Add]所属情報コンテキスト追加

### DIFF
--- a/app/controllers/user/users_controller.rb
+++ b/app/controllers/user/users_controller.rb
@@ -17,6 +17,27 @@ class User::UsersController < ApplicationController
 		end
 	end
 
+	def fetch_membership
+		login_user = User.find_by(email: input_user_params[:email])
+		if login_user.nil?
+			render json: { error: I18n.t('user.users.get_user_info.failed') }, status: :bad_request
+		end
+
+		login_membership = Membership.with_users(login_user.id).current.first
+		if login_membership.nil?
+			render json: { error: I18n.t('user.users.fetch_membership.failed') }, status: :bad_request
+		else
+			render json: { membership: {
+				id: login_membership[:id],
+				user_id: login_membership[:user_id],
+				store_id: login_membership[:store_id],
+				current_store: login_membership[:current_store],
+				calendar_id: login_membership[:calendar_id],
+				privilege: login_membership[:privilege],
+			} }
+		end
+	end
+
 	private
 
 	def input_params

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -18,6 +18,9 @@ ja:
         success: "minshifへ、ようこそ"
       get_user_info:
         failed: "ユーザが見つかりませんでした"
+      fetch_membership:
+        failed: "所属情報が見つかりませんでした"
+        success: "所属情報を取得しました"
   shift:
     shifts:
       fetch_shifts:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
 	namespace 'user' do
 		post '/create', to: 'users#create'
 		get '/get_user_info', to: 'users#get_user_info'
+		get '/fetch_membership', to: 'users#fetch_membership'
 	end
 
 	namespace 'shift' do


### PR DESCRIPTION
## 概要
所属情報コンテキストを追加しました．

## 変更点
- シフト情報やシフト提出依頼等の権限が必要な機能を作成するために所属情報コンテキストを追加
- ルーティングを追加

## 動作要件
- `GET /user/fetch_membership`

## 影響範囲
- ログイン状態管理


## テスト
1. メールアドレスを添付してGET送信
2. 所属情報が返される
