### PR TITLE
[Fix]Port対応

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,6 @@ COPY . /minshif/
 RUN bundle exec rails assets:precompile
 RUN bundle exec rails db:migrate
 
+EXPOSE 8000
+
 CMD ["bundle", "exec", "rails", "server", "-p", "8000", "-b", "0.0.0.0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,4 @@ COPY . /minshif/
 RUN bundle exec rails assets:precompile
 RUN bundle exec rails db:migrate
 
-CMD ["bundle", "exec", "rails", "server", "-b", "0.0.0.0"]
+CMD ["bundle", "exec", "rails", "server", "-p", "8000", "-b", "0.0.0.0"]


### PR DESCRIPTION
## 概要
Portエラーの対応を行いました．

## 変更点
- Dockerfile内でPortに接続できるように変更しました．

エラー内容
```
==> Port scan timeout reached, no open ports detected.
Bind your service to at least one port.
If you don't need to receive traffic on any port, create a background worker instead.
```

参考：Renderへの問い合わせ
> docker-compose is not supported within Render services, so that file isn't being used at all. You'll want to ensure that everything you need to install dependencies, listen on an interface, expose ports, and start the server is located within your Dockerfile instead.
