### PR TITLE
[Add]店舗のバリデーション機能追加

### DIFF
--- a/app/controllers/store/store_controller.rb
+++ b/app/controllers/store/store_controller.rb
@@ -20,7 +20,7 @@ class Store::StoreController < ApplicationController
 				user_id: login_user.id,
 				store_id: store.id,
 				current_store: true,
-				privilege: 2
+				privilege: :manager
 			)
 			render json: { response: I18n.t('store.stores.create.success') }
 		rescue ActiveRecord::RecordInvalid => e

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -1,16 +1,15 @@
 class Membership < ApplicationRecord
 	belongs_to :user, class_name: 'User', foreign_key: 'user_id'
 	belongs_to :store, class_name: 'Store', foreign_key: 'store_id'
-
 	has_many :shifts
 	has_many :invitations
+
+	before_save :ensure_only_one_current_store if :current_store_changed?
 
 	enum :privilege, { staff: 1, manager: 2, developer: 3 }
 
 	scope :current, -> { where(current_store: true) }
-
 	scope :with_users, ->(user_id) { where(user_id: user_id) }
-
 	scope :with_stores, ->(store_id) { where(store_id: store_id) }
 
 	def self.create_with_invitation(invitation_id, user_id)
@@ -22,12 +21,18 @@ class Membership < ApplicationRecord
 
 			manager_membership = Membership.find_by(id: invitation.membership_id)
 			if manager_membership
-				Membership.create!(user_id: user_id, store_id: manager_membership.store_id, current_store: true, privilege: 1)
+				Membership.create!(user_id: user_id, store_id: manager_membership.store_id, current_store: true, privilege: :staff)
 			else
 				I18n.t('invitation.invitations.create.invalid_manager_info')
 			end
 		rescue StandardError => e
 			e.message
 		end
+	end
+
+	private
+
+	def ensure_only_one_current_store
+		Membership.where(user_id: user_id).where.not(id: id).update_all(current_store: false)
 	end
 end

--- a/app/services/user_service.rb
+++ b/app/services/user_service.rb
@@ -13,7 +13,7 @@ class UserService
 			# ユーザの保存
 			if user.update(input_params[:user])
 				begin
-					Membership.create_with_invitation(invitation_id[:invitation_id], user.id) if invitation_id[:invitation_id].present?
+					Membership.create_with_invitation(invitation_id, user.id) if invitation_id.present?
 					# 店舗に所属しているか
 					is_affiliated = Membership.current.with_users(user.id).count > 0
 					{ success?: true, message: I18n.t('user.users.create.success'), is_affiliated: is_affiliated }

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe Membership, type: :model do
+	describe 'create a new membership' do
+		let(:user) { create(:user) }
+		let(:store) { create(:store) }
+		let!(:membership) { create(:membership, user: user, store: store, current_store: true) }
+
+		context 'with valid attributes' do
+			it 'creates a user and store membership' do
+				expect(membership.user_id).to eq(user.id)
+				expect(membership.store_id).to eq(store.id)
+				expect(membership.current_store).to eq(true)
+			end
+
+			context 'with different store' do
+				let(:new_store) { create(:store) }
+				let!(:new_membership) { create(:membership, user: user, store: new_store, current_store: true) }
+
+				it 'changes the current store' do
+					expect(new_membership.user_id).to eq(user.id)
+					expect(new_membership.store_id).to eq(new_store.id)
+					expect(new_membership.current_store).to eq(true)
+					membership.reload
+					expect(membership.current_store).to eq(false)
+				end
+			end
+		end
+	end
+end


### PR DESCRIPTION
## 概要
店舗のバリデーションを追加しました．


## 変更点
- 店舗作成時に，既に店舗に所属しているユーザは新規店舗のみに`current_store: true`となるよう変更
- enumの利用
- テストの作成


## 影響範囲
- 既存店舗に所属しているユーザ



## テスト
- rspec実行
- 店舗に所属している状態で，店舗を新規作成
