### PR TITLE
[Fix]ジョブの分割

### DIFF
--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -31,7 +31,7 @@ class InvitationsController < ApplicationController
 					)
 					render json: { message: I18n.t('invitation.invitations.create.success') }
 				rescue StandardError => e
-					render json: { error: e.message }
+					render json: { error: e.message }, status: :unprocessable_entity
 				end
 			else
 				# マジックリンク生成
@@ -52,7 +52,7 @@ class InvitationsController < ApplicationController
 					)
 					render json: { message: I18n.t('invitation.invitations.create.success_invited') }
 				rescue StandardError => e
-					render json: { error: e.message }
+					render json: { error: e.message }, status: :unprocessable_entity
 				end
 			end
 		rescue StandardError => e

--- a/app/controllers/line_bots_controller.rb
+++ b/app/controllers/line_bots_controller.rb
@@ -73,7 +73,7 @@ class LineBotsController < ApplicationController
 		if AuthCode.create(input_register_params[:auth_code], input_register_params[:user_id])
 			render json: { message: I18n.t('line_bot.create.success') }, status: :ok
 		else
-			render json: { message: I18n.t('line_bot.create.failed') }, status: :not_found
+			render json: { error: I18n.t('line_bot.create.failed') }, status: :bad_request
 		end
 	end
 

--- a/app/controllers/line_bots_controller.rb
+++ b/app/controllers/line_bots_controller.rb
@@ -1,16 +1,10 @@
 require 'line/bot'
 
 class LineBotsController < ApplicationController
-	def send_shift_message(line_user_id, store_name, start_time, end_time)
-		tomorrow = Date.tomorrow.strftime('%m/%d')
+	def send_shift_message(line_user_id, text_lines)
 		message = {
 			type: 'text',
-			text: I18n.t('line_bot.send_shift_message.notify',
-				date: tomorrow,
-				store_name: store_name,
-				start_time: start_time.strftime('%H:%M'),
-				end_time: end_time.strftime('%H:%M')
-			)
+			text: text_lines
 		}
 		client.push_message(line_user_id, message)
 	end

--- a/app/controllers/shifts_controller.rb
+++ b/app/controllers/shifts_controller.rb
@@ -124,8 +124,7 @@ class ShiftsController < ApplicationController
 	end
 
 	def input_index_params
-		params.require(:fetch_shift).permit(:start_date, :end_date)
-		params.permit(:id)
+		params.require(:fetch_shift).permit(:start_date, :end_date).merge(params.permit(:id))
 	end
 
 

--- a/app/controllers/stores_controller.rb
+++ b/app/controllers/stores_controller.rb
@@ -38,7 +38,7 @@ class StoresController < ApplicationController
 				current_store: true,
 				privilege: :manager
 			)
-			render json: { response: I18n.t('store.stores.create.success') }
+			render json: { message: I18n.t('store.stores.create.success') }
 		rescue ActiveRecord::RecordInvalid => e
 			render json: { error: e.message }
 		end
@@ -53,11 +53,11 @@ class StoresController < ApplicationController
 		end
 		stores = search_store_info(user_id)
 		if stores.is_a?(Hash) && stores[:error]
-			render json: stores, status: stores[:status]
+			render json: { error: stores }, status: stores[:status]
 			return
 		end
 
-		render json: stores
+		render json: { data: stores }
 	end
 
 	private

--- a/app/jobs/scheduled_shift_message_job.rb
+++ b/app/jobs/scheduled_shift_message_job.rb
@@ -11,7 +11,7 @@ class ScheduledShiftMessageJob < ApplicationJob
 			.order(start_time: :asc)
 			.pluck('users.line_user_id', 'shifts.start_time', 'shifts.end_time', 'stores.store_name')
 
-		grouped = tomorrow_shifts.group_by { |record| record[0] }
+		grouped = tomorrow_shifts.group_by { |line_user_id, _, _, _| line_user_id }
 
 		grouped.each do |line_user_id, user_shifts|
 			text_lines = []
@@ -19,7 +19,7 @@ class ScheduledShiftMessageJob < ApplicationJob
 
 			last_store_name = nil
 
-			user_shifts.map do |_, start_time, end_time, store_name|
+			user_shifts.each do |_, start_time, end_time, store_name|
 				if store_name != last_store_name
 					text_lines << I18n.t('line_bot.send_shift_message.notify.store_name', store_name: store_name)
 					last_store_name = store_name

--- a/app/jobs/user_shift_notification_job.rb
+++ b/app/jobs/user_shift_notification_job.rb
@@ -1,0 +1,7 @@
+class UserShiftNotificationJob < ApplicationJob
+	queue_as :default
+
+	def perform(line_user_id, store_name, start_time, end_time)
+		LineBotsController.new.send_shift_message(line_user_id, store_name, start_time, end_time)
+	end
+end

--- a/app/jobs/user_shift_notification_job.rb
+++ b/app/jobs/user_shift_notification_job.rb
@@ -1,7 +1,7 @@
 class UserShiftNotificationJob < ApplicationJob
 	queue_as :default
 
-	def perform(line_user_id, store_name, start_time, end_time)
-		LineBotsController.new.send_shift_message(line_user_id, store_name, start_time, end_time)
+	def perform(line_user_id, text_lines)
+		LineBotsController.new.send_shift_message(line_user_id, text_lines)
 	end
 end

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -54,7 +54,7 @@ ja:
         failed: "店舗の切り替えに失敗しました"
       create:
         success: "店舗を作成しました"
-        already_created: "指定された店舗名は既に作成されています"
+        already_created: "その店舗名は既に使用されています"
         empty: "店舗名が登録されていません"
       fetch:
         not_found_user: "ユーザが取得できませんでした"

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -99,7 +99,11 @@ ja:
       invalid_code: "チャットしていただきありがとうございます！\nLINE Botは個別にチャットすることはできません😭\n\n使い方の詳細は「ヘルプ」とお問合せください"
       not_text: "チャットしていただきありがとうございます！\nLINE Botはテキストのみの対応です😭\nご了承ください"
     send_shift_message:
-      notify: "%{date} 【%{store_name}】でのシフトが予定されています。\n勤務時間は %{start_time} ~ %{end_time} です。\nお忘れなくご準備ください！"
+      notify:
+        header: "明日 %{date} に以下のシフトが予定されています。"
+        store_name: "【%{store_name}】"
+        shift_time: "・%{start_time} ~ %{end_time}"
+        footer: "お忘れなくご準備ください！"
       register:
         header: "【%{store_name}】で以下のシフトが登録されました。\n"
         shift_time: "・%{date} %{start_time} ~ %{end_time}"

--- a/spec/controllers/line_bots_controller_spec.rb
+++ b/spec/controllers/line_bots_controller_spec.rb
@@ -18,17 +18,22 @@ RSpec.describe LineBotsController, type: :controller do
 
 		it 'sends a shift reminder message to the specified user' do
 			tomorrow = Date.tomorrow.strftime('%m/%d')
+			text_lines = []
+			text_lines << I18n.t('line_bot.send_shift_message.notify.header', date: tomorrow)
+			text_lines << I18n.t('line_bot.send_shift_message.notify.store_name', store_name: store_name)
+			text_lines << I18n.t('line_bot.send_shift_message.notify.shift_time',
+				start_time: start_time,
+				end_time: end_time
+			)
+			text_lines << I18n.t('line_bot.send_shift_message.notify.footer')
+
 			expected_message = {
 				type: 'text',
-				text: I18n.t('line_bot.send_shift_message.notify',
-							date: tomorrow,
-							store_name: store_name,
-							start_time: start_time.strftime('%H:%M'),
-							end_time: end_time.strftime('%H:%M'))
+				text: text_lines
 			}
 
 			expect(client).to receive(:push_message).with(user_id, expected_message)
-			controller.send_shift_message(user_id, store_name, start_time, end_time)
+			controller.send_shift_message(user_id, text_lines)
 		end
 	end
 end

--- a/spec/controllers/stores_controller_spec.rb
+++ b/spec/controllers/stores_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe StoresController, type: :controller do
 				}.to change(Store, :count).by(1)
 
 				expect(JSON.parse(response.body)).to eq({
-					"response"	=> I18n.t('store.stores.create.success')
+					"message"	=> I18n.t('store.stores.create.success')
 				})
 				expect(response).to have_http_status(200)
 			end

--- a/spec/jobs/scheduled_shift_message_job_spec.rb
+++ b/spec/jobs/scheduled_shift_message_job_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.describe ScheduledShiftMessageJob, type: :job do
 	let(:store_name) { 'minshif店' }
-	let(:start_time) { Time.zone.parse('2000-01-01 09:00:00.000000000 +0000') }
-	let(:end_time) { Time.zone.parse('2000-01-01 18:00:00.000000000 +0000') }
+	let(:start_time) { Time.zone.parse('09:00:00') }
+	let(:end_time) { Time.zone.parse('18:00:00') }
 	let(:line_user_id) { "U1234567890" }
 
 	before(:each) do
@@ -13,18 +13,24 @@ RSpec.describe ScheduledShiftMessageJob, type: :job do
 		create(:shift, membership: membership, shift_date: Date.tomorrow, start_time: start_time, end_time: end_time)
 	end
 
-	it 'calls LineBotsController#send_shift_message with the correct user ID' do
+	it 'calls UserShiftNotificationJob with the correct args' do
 		line_bot_controller = instance_double(LineBotsController)
 		allow(LineBotsController).to receive(:new).and_return(line_bot_controller)
 
-		jst_start_time = start_time + 9.hours
-		jst_end_time = end_time + 9.hours
+		tomorrow = Date.tomorrow
 
-		expect(line_bot_controller).to receive(:send_shift_message).with(
+		text_lines = []
+		text_lines << I18n.t('line_bot.send_shift_message.notify.header', date: tomorrow)
+		text_lines << I18n.t('line_bot.send_shift_message.notify.store_name', store_name: store_name)
+		text_lines << I18n.t('line_bot.send_shift_message.notify.shift_time',
+			start_time: start_time.strftime('%H:%M'),
+			end_time: end_time.strftime('%H:%M')
+		)
+		text_lines << I18n.t('line_bot.send_shift_message.notify.footer')
+
+		expect(UserShiftNotificationJob).to receive(:perform_later).with(
 			line_user_id,
-			store_name,
-			jst_start_time,
-			jst_end_time
+			text_lines
 		)
 
 		ScheduledShiftMessageJob.new.perform


### PR DESCRIPTION
## 概要
定期実行するジョブを分割して効率的に処理するよう変更しました．

## 変更点
- DBから抽出するSQLの効率化
- DBから抽出した情報に対するuserごとののグループ化
- ジョブをUserShiftNotificationJobに切り分け
- LINEへ送信するメッセージの変更および複数シフト対応

## 備考
- line_user_idを登録していないと実行されない機能
- ワーカーを3つ設定しているため，UserShiftNotificationJobは空いているワーカーが順に実行するよう指定
